### PR TITLE
Add install script back, add windows section.

### DIFF
--- a/Tools/node/package.json
+++ b/Tools/node/package.json
@@ -10,6 +10,7 @@
   "keywords": ["bebop", "binary", "serialization", "compiler"],
   "scripts": {
     "compile": "tsc -p ./",
+    "install": "node ./scripts/install.js",
     "watch": "tsc -watch -p ./"
   },
   "bin": {

--- a/Tools/node/scripts/install.js
+++ b/Tools/node/scripts/install.js
@@ -1,0 +1,16 @@
+const child_process = require('child_process')
+const path = require('path')
+const toolsDir = path.resolve(__dirname, '../tools')
+
+if (process.platform === "darwin") {
+    const executable = path.resolve(toolsDir, 'macos/bebopc')
+    child_process.execSync(`chmod +x "${executable}"`, {stdio: 'ignore'})
+}
+else if (process.platform === "linux") {
+    const executable = path.resolve(toolsDir, 'linux/bebopc')
+    child_process.execSync(`chmod +x "${executable}"`, {stdio: 'ignore'})
+}
+else if (process.platform === "win32") {
+    const executable = path.resolve(toolsDir, 'windows/bebopc.exe')
+    child_process.execSync(`Unblock-File -Path "${executable}"`, {stdio: 'ignore', shell: "powershell.exe"})
+}


### PR DESCRIPTION
Fix for bebopc failing on mac (and ostensibly linux) due to wrong permissions. Re-adds a script to set +x on the executables and adds a section that unblocks the file on windows.