### PR TITLE
Fix .NET build-tools on Unix systems

### DIFF
--- a/Compiler/CommandLineFlags.cs
+++ b/Compiler/CommandLineFlags.cs
@@ -132,7 +132,7 @@ namespace Compiler
         /// <summary>
         /// A collection of all values associated with the current flag.
         /// </summary>
-        public string[] Values { get; set; }
+        public string[] Values { get; init; }
         /// <summary>
         /// The name of the current flag.
         /// </summary>

--- a/Compiler/CommandLineFlags.cs
+++ b/Compiler/CommandLineFlags.cs
@@ -126,7 +126,7 @@ namespace Compiler
         /// <returns></returns>
         public string? GetValue()
         {
-            return Values.FirstOrDefault();
+            return Values.FirstOrDefault()?.Trim();
         }
 
         /// <summary>

--- a/Compiler/Program.cs
+++ b/Compiler/Program.cs
@@ -28,11 +28,11 @@ namespace Compiler
             }
         }
 
-        private static async Task<int> Main(string[] args)
+        private static async Task<int> Main()
         {
-            Log.Formatter = CommandLineFlags.FindLogFormatter(args);
+            Log.Formatter = CommandLineFlags.FindLogFormatter(Environment.GetCommandLineArgs());
 
-            if (!CommandLineFlags.TryParse(Environment.CommandLine.Split(' '), out _flags, out var message))
+            if (!CommandLineFlags.TryParse(Environment.GetCommandLineArgs(), out _flags, out var message))
             {
                 await Log.Error(new CompilerException(message));
                 return 1;

--- a/Compiler/Program.cs
+++ b/Compiler/Program.cs
@@ -32,7 +32,7 @@ namespace Compiler
         {
             Log.Formatter = CommandLineFlags.FindLogFormatter(args);
 
-            if (!CommandLineFlags.TryParse(args, out _flags, out var message))
+            if (!CommandLineFlags.TryParse(Environment.CommandLine.Split(' '), out _flags, out var message))
             {
                 await Log.Error(new CompilerException(message));
                 return 1;

--- a/Tools/C#/build/bebop-tools.targets
+++ b/Tools/C#/build/bebop-tools.targets
@@ -16,9 +16,9 @@
         <_Bebopc Condition="'$(IsWindows)' == 'true'">"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\windows\bebopc.exe'))"</_Bebopc>
         <_Bebopc Condition="'$(IsMac)' == 'true'">"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../tools/macos/bebopc'))"</_Bebopc>
         <_Bebopc Condition="'$(IsLinux)' == 'true'">"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../tools/linux/bebopc'))"</_Bebopc>
-        <_BebopSchemas>"@(Bebop -> '%(FullPath)', ' ')"</_BebopSchemas>
+        <_BebopSchemas>@(Bebop -> '"%(FullPath)"', ' ')</_BebopSchemas>
     </PropertyGroup>
-    <Target Name="CompileBops" BeforeTargets="CoreCompile" DependsOnTargets="PrepareForBuild">
+    <Target Name="CompileBops" BeforeTargets="CoreCompile" DependsOnTargets="PrepareForBuild" Condition="'$(_BebopSchemas)' != '' " >
         <Exec
             Command="$(_Bebopc) --log-format MSBuild --cs &quot;$([System.IO.Path]::GetFullPath('%(Bebop.OutputDir)'))%(Bebop.OutputFile)&quot; --namespace %(Bebop.Namespace) --files $(_BebopSchemas)"
             EchoOff='true'

--- a/Tools/C#/build/bebop-tools.targets
+++ b/Tools/C#/build/bebop-tools.targets
@@ -1,55 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <Project ToolsVersion="4.0" InitialTargets="CompileBops" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-	<PropertyGroup>
-		<IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
-		<IsOSX
-			Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">
-			true
-		</IsOSX>
-		<IsLinux
-			Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">
-			true
-		</IsLinux>
-	</PropertyGroup>
-
-	<ItemDefinitionGroup>
-		<Bebop>
-			<OutputDir Condition="'%(Bebop.OutputDir)' == '' " >$(MSBuildProjectDirectory)\</OutputDir>
-			<OutputFile Condition="'%(Bebop.OutputFile)' == '' " />
-			<Namespace Condition="'%(Bebop.Namespace)' == '' " />
-		</Bebop>
-	</ItemDefinitionGroup>
-
-
-	<PropertyGroup>
-		<_BebopcRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../tools/'))</_BebopcRoot>
-		<_Bebopc Condition="'$(IsWindows)' == 'true'">"$(_BebopcRoot)windows\bebopc.exe"</_Bebopc>
-		<_Bebopc Condition="'$(IsOSX)' == 'true'">"$(_BebopcRoot)macos\bebopc"</_Bebopc>
-		<_Bebopc Condition="'$(IsLinux)' == 'true'">"$(_BebopcRoot)linux\bebopc"</_Bebopc>
-		<_BebopSchemas>"@(Bebop -> '%(FullPath)', ' ')"</_BebopSchemas>
-	</PropertyGroup>
-
-
-	<Target Name="CompileBops" BeforeTargets="CoreCompile" DependsOnTargets="PrepareForBuild">
-
-		<Exec
-			Command="$(_Bebopc) --log-format MSBuild --cs &quot;$([System.IO.Path]::GetFullPath('%(Bebop.OutputDir)'))\%(Bebop.OutputFile)&quot; --namespace %(Bebop.Namespace) --files $(_BebopSchemas)"
-			EchoOff='true'
-			StandardErrorImportance='high'
-			StandardOutputImportance='low'
-			ConsoleToMSBuild='true'
-			ContinueOnError='false'
-			StdOutEncoding='utf-8'>
-			<Output TaskParameter="ConsoleOutput" PropertyName="_BebopCompiler" />
-			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
-		</Exec>
-
-	</Target>
-
-
+    <PropertyGroup>
+        <IsWindows Condition="$([MSBuild]::IsOSPlatform('Windows'))" >true</IsWindows>
+        <IsMac Condition="$([MSBuild]::IsOSPlatform('OSX'))" >true</IsMac>
+        <IsLinux Condition="$([MSBuild]::IsOSPlatform('Linux'))" >true</IsLinux>
+    </PropertyGroup>
+    <ItemDefinitionGroup>
+        <Bebop>
+            <OutputDir Condition="'%(Bebop.OutputDir)' == '' " >$(MSBuildProjectDirectory)\</OutputDir>
+            <OutputFile Condition="'%(Bebop.OutputFile)' == '' " />
+            <Namespace Condition="'%(Bebop.Namespace)' == '' " />
+        </Bebop>
+    </ItemDefinitionGroup>
+    <PropertyGroup>
+        <_Bebopc Condition="'$(IsWindows)' == 'true'">"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\tools\windows\bebopc.exe'))"</_Bebopc>
+        <_Bebopc Condition="'$(IsMac)' == 'true'">"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../tools/macos/bebopc'))"</_Bebopc>
+        <_Bebopc Condition="'$(IsLinux)' == 'true'">"$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../tools/linux/bebopc'))"</_Bebopc>
+        <_BebopSchemas>"@(Bebop -> '%(FullPath)', ' ')"</_BebopSchemas>
+    </PropertyGroup>
+    <Target Name="CompileBops" BeforeTargets="CoreCompile" DependsOnTargets="PrepareForBuild">
+        <Exec
+            Command="$(_Bebopc) --log-format MSBuild --cs &quot;$([System.IO.Path]::GetFullPath('%(Bebop.OutputDir)'))%(Bebop.OutputFile)&quot; --namespace %(Bebop.Namespace) --files $(_BebopSchemas)"
+            EchoOff='true'
+            StandardErrorImportance='high'
+            StandardOutputImportance='low'
+            ConsoleToMSBuild='true'
+            ContinueOnError='false'
+            StdOutEncoding='utf-8'>
+            <Output TaskParameter="ConsoleOutput" PropertyName="_BebopCompiler" />
+            <Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
+        </Exec>
+    </Target>
 </Project>


### PR DESCRIPTION
As it turns out the check for the OS wasn't working and this causes the compiler path not to be set on macOS and Linux. This change simplifies the check and path setting.

This fixes #64 