### PR TITLE
Overflow Fix

### DIFF
--- a/Runtime/C#/Exceptions/BebopRuntimeException.cs
+++ b/Runtime/C#/Exceptions/BebopRuntimeException.cs
@@ -11,11 +11,11 @@ namespace Bebop.Exceptions
     {
         /// <inheritdoc />
         public BebopRuntimeException(BebopRecord first, BebopRecord second) : base(
-            $"Bebop type \"{first.Type.FullName}\" and \"{second.Type.FullName}\" cannot have same opcode\"{first.OpCode}\"")
+            $"Bebop type '{first.Type.FullName}' and '{second.Type.FullName}' cannot have same opcode'{first.OpCode}'")
         {
         }
         /// <inheritdoc />
-        public BebopRuntimeException(uint opcode) : base($"A Bebop type with opcode \"{opcode:X}\" does not exist.")
+        public BebopRuntimeException(uint opcode) : base($"A Bebop type with opcode 0x'{opcode:X}' does not exist.")
         {
         }
         /// <inheritdoc />
@@ -31,7 +31,7 @@ namespace Bebop.Exceptions
         }
         /// <inheritdoc />
         public BebopRuntimeException(Type first, Type second) : base(
-            $"Bebop type \"{first.FullName}\" does not align with \"{second.FullName}\"")
+            $"Bebop type '{first.FullName}' does not align with '{second.FullName}'")
         {
         }
         /// <inheritdoc />

--- a/Runtime/C#/Extensions/TypeExtensions.cs
+++ b/Runtime/C#/Extensions/TypeExtensions.cs
@@ -37,7 +37,7 @@ namespace Bebop.Extensions
                 null);
             if (decodeMethod is null)
             {
-                throw new BebopRuntimeException($"Unable to find static decode method in \"{type.FullName}\"");
+                throw new BebopRuntimeException($"Unable to find static decode method in '{type.FullName}'");
             }
             return decodeMethod;
         }
@@ -96,7 +96,7 @@ namespace Bebop.Extensions
 
             if (encodeMethod is null)
             {
-                throw new BebopRuntimeException($"Unable to find static encode method in \"{type.FullName}\"");
+                throw new BebopRuntimeException($"Unable to find static encode method in '{type.FullName}'");
             }
             return encodeMethod;
         }
@@ -175,7 +175,7 @@ namespace Bebop.Extensions
                         .Where(subHandler => subHandler.Value.Any(l => l.RecordType == binding.RecordType)))
                     {
                         throw new BebopRuntimeException(
-                            $"Duplicate bindings found for \"{binding.RecordType}\" in \"{handler.Key}\" and \"{subHandler.Key}\"");
+                            $"Duplicate bindings found for '{binding.RecordType}' in '{handler.Key}' and '{subHandler.Key}'");
                     }
                 }
             }

--- a/Runtime/C#/Extensions/TypeExtensions.cs
+++ b/Runtime/C#/Extensions/TypeExtensions.cs
@@ -56,7 +56,7 @@ namespace Bebop.Extensions
 
             if (type.BaseType is null)
             {
-                throw new BebopRuntimeException($"Provided type \"{type.FullName}\" does not contain a base class.");
+                throw new BebopRuntimeException($"Provided type '{type.FullName}' does not contain a base class.");
             }
 
             var decodeMethod = type.GetStaticDecode();
@@ -69,12 +69,10 @@ namespace Bebop.Extensions
             if (constructor is null)
             {
                 throw new BebopRuntimeException(
-                    $"Cannot locate constructor for BebopType<T> using \"{type.FullName}\"");
+                    $"Cannot locate constructor for BebopType<T> using '{type.FullName}'");
             }
 
-            var opcode = type.BaseType.GetField(opcodeFieldName)?.GetRawConstantValue() is uint v
-                ? (int) v
-                : -1;
+            uint? opcode = type.BaseType.GetField(opcodeFieldName)?.GetRawConstantValue() is uint v ? v : null;
 
             return (BebopRecord) constructor.Invoke(new object[] {type, encodeMethod, decodeMethod, opcode});
         }

--- a/Runtime/C#/Extensions/TypeExtensions.cs
+++ b/Runtime/C#/Extensions/TypeExtensions.cs
@@ -74,7 +74,7 @@ namespace Bebop.Extensions
 
             uint? opcode = type.BaseType.GetField(opcodeFieldName)?.GetRawConstantValue() is uint v ? v : null;
 
-            return (BebopRecord) constructor.Invoke(new object[] {type, encodeMethod, decodeMethod, opcode});
+            return (BebopRecord) constructor.Invoke(new object[] {type, encodeMethod, decodeMethod, opcode!});
         }
 
         /// <summary>

--- a/Runtime/C#/Runtime/BebopMirror.cs
+++ b/Runtime/C#/Runtime/BebopMirror.cs
@@ -59,7 +59,7 @@ namespace Bebop.Runtime
         /// <returns>A virtual <see cref="BebopRecord"/> accessor.</returns>
         public static BebopRecord GetRecord(string recordName) => DefinedRecords
                 .FirstOrDefault(definedType => definedType.Type.Name.Equals(recordName)) ??
-            throw new BebopRuntimeException($"A record named \"{recordName}\" does not exist.");
+            throw new BebopRuntimeException($"A record named '{recordName}' does not exist.");
 
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Bebop.Runtime
                     return record;
                 }
             }
-            throw new BebopRuntimeException($"A record with the type of \"{nameof(T)}\" does not exist.");
+            throw new BebopRuntimeException($"A record with the type of '{nameof(T)}' does not exist.");
         }
 
         /// <summary>

--- a/Runtime/C#/Runtime/BebopMirror.cs
+++ b/Runtime/C#/Runtime/BebopMirror.cs
@@ -212,7 +212,7 @@ namespace Bebop.Runtime
                 var handlerInstance = !handler.Key.IsStaticClass() ? Activator.CreateInstance(handler.Key) : new StaticClass();
                 if (handlerInstance is null)
                 {
-                    throw new BebopRuntimeException($"Unable to create instance of \"{handler.Key}\"");
+                    throw new BebopRuntimeException($"Unable to create instance of '{handler.Key}'");
                 }
                 foreach (var binding in handler.Value)
                 {
@@ -235,13 +235,13 @@ namespace Bebop.Runtime
                     {
                         record.AssignHandler(handlers.FindBindingInfo(record.GetType()).Method, handlerInstance);
                     }
-                    if (record is {OpCode: > -1})
+                    if (record is {OpCode: not null})
                     {
-                        if (opcodeTypes.ContainsKey((uint) record.OpCode))
+                        if (opcodeTypes.ContainsKey(record.OpCode.Value))
                         {
-                            throw new BebopRuntimeException(opcodeTypes[(uint) record.OpCode], record);
+                            throw new BebopRuntimeException(opcodeTypes[record.OpCode.Value], record);
                         }
-                        opcodeTypes.Add((uint) record.OpCode, record);
+                        opcodeTypes.Add(record.OpCode.Value, record);
                     }
                     concreteRecords[record.Type] = record;
                     definedRecords.Add(record);

--- a/Runtime/C#/Runtime/BebopRecord.cs
+++ b/Runtime/C#/Runtime/BebopRecord.cs
@@ -26,7 +26,7 @@ namespace Bebop.Runtime
 
         ///<inheritdoc cref="BebopRecord{T}.OpCode"/>
         // ReSharper disable once UnassignedGetOnlyAutoProperty
-        public virtual int OpCode { get; }
+        public virtual uint? OpCode { get; }
 
         ///<inheritdoc cref="BebopRecord{T}.Encode"/>
         public virtual byte[] Encode(object record) => throw new NotImplementedException();
@@ -94,7 +94,7 @@ namespace Bebop.Runtime
         ///     <typeparamref name="T"/>
         /// </param>
         /// <param name="opcode">The opcode constant (if any) that is in <typeparamref name="T"/></param>
-        private BebopRecord(Type type, MethodInfo encodeMethod, MethodInfo decodeMethod, int opcode)
+        private BebopRecord(Type type, MethodInfo encodeMethod, MethodInfo decodeMethod, uint? opcode)
         {
             // create delegates to the encode and decode methods so we have a pointer.
             _encodeDelegate = (encodeMethod.CreateDelegate(typeof(Func<T, byte[]>)) as Func<T, byte[]>)!;
@@ -106,10 +106,7 @@ namespace Bebop.Runtime
         /// <summary>
         ///     The opcode attribute constant
         /// </summary>
-        /// <remarks>
-        ///     -1 if no opcode was defined in <typeparamref name="T"/>
-        /// </remarks>
-        public override int OpCode { get; }
+        public override uint? OpCode { get; }
 
         /// <summary>
         ///     The actual Bebop aggregate implementation type

--- a/Runtime/C#/Runtime/BebopRecord.cs
+++ b/Runtime/C#/Runtime/BebopRecord.cs
@@ -176,11 +176,11 @@ namespace Bebop.Runtime
         {
             if (record is not T r)
             {
-                throw new BebopRuntimeException($"The provided record \"{typeof(T1)}\" cannot be assigned to the defined type \"{typeof(T)}\"");
+                throw new BebopRuntimeException($"The provided record '{typeof(T1)}' cannot be assigned to the defined type '{typeof(T)}'");
             }
             if (_handlerTaskDelegate is null && _handlerValueTaskDelegate is null && _handlerVoidDelegate is null)
             {
-                throw new BebopRuntimeException($"No handler is assigned to \"{typeof(T)}\"");
+                throw new BebopRuntimeException($"No handler is assigned to '{typeof(T)}'");
             }
             InvokeHandler(state, r);
         }
@@ -195,11 +195,11 @@ namespace Bebop.Runtime
         {
             if (record is not T r)
             {
-                throw new BebopRuntimeException($"The provided record \"{record.GetType()}\" cannot be assigned to the defined type \"{typeof(T)}\"");
+                throw new BebopRuntimeException($"The provided record '{record.GetType()}' cannot be assigned to the defined type '{typeof(T)}'");
             }
             if (_handlerTaskDelegate is null && _handlerValueTaskDelegate is null && _handlerVoidDelegate is null)
             {
-                throw new BebopRuntimeException($"No handler is assigned to \"{typeof(T)}\"");
+                throw new BebopRuntimeException($"No handler is assigned to '{typeof(T)}'");
             }
             InvokeHandler(state, r);
         }


### PR DESCRIPTION
Casting unsigned opcodes to a signed integer was causing overflow issues that would turn values over 2,147,483,647 into a bit pattern interpreted as a signed integer. after that any subsequent lookups of the original unsigned opcode value would fail.

To fix this we now use a nullable type for BebopRecord rather than using '-1' to signify that a record didn't have one.