### PR TITLE
Properly parse unsigned constants

### DIFF
--- a/Core/Exceptions/Exceptions.cs
+++ b/Core/Exceptions/Exceptions.cs
@@ -38,6 +38,7 @@ namespace Core.Exceptions
         public UnrecognizedTokenException(char tokenStart, Span span)
             : base($"Unrecognized token start '{tokenStart}'", span, 100) { }
     }
+   
     [Serializable]
     class MultipleDefinitionsException : SpanException
     {
@@ -109,5 +110,12 @@ namespace Core.Exceptions
     {
         public InvalidMapKeyTypeException(TypeBase type)
             : base($"Type '{type.AsString}' is an invalid key type for a map. Only booleans, numbers, strings, and GUIDs can be used as keys.", type.Span, 111) { }
+    }
+
+    [Serializable]
+    class DuplicateFieldException : SpanException
+    {
+        public DuplicateFieldException(IField field, IDefinition definition)
+            : base($"The type '{definition.Name}' already contains a definition for '{field.Name}'", field.Span, 112) { }
     }
 }

--- a/Core/Meta/BebopSchema.cs
+++ b/Core/Meta/BebopSchema.cs
@@ -26,7 +26,7 @@ namespace Core.Meta
 
             foreach (var definition in Definitions.Values)
             {
-                if (Definitions.Values.Count(d => d.Name.Equals(definition.Name)) > 1)
+                if (Definitions.Values.Count(d => d.Name.Equals(definition.Name, StringComparison.OrdinalIgnoreCase)) > 1)
                 {
                     throw new MultipleDefinitionsException(definition);
                 }
@@ -63,12 +63,12 @@ namespace Core.Meta
                     {
                         throw new InvalidDeprecatedAttributeUsageException(field);
                     }
+                    if (definition.Fields.Count(f => f.Name.Equals(field.Name, StringComparison.OrdinalIgnoreCase)) > 1)
+                    {
+                        throw new DuplicateFieldException(field, definition);
+                    }
                     switch (definition.Kind)
                     {
-                        case AggregateKind.Enum when field.ConstantValue < 0:
-                        {
-                            throw new InvalidFieldException(field, "Enum values must start at 0");
-                        }
                         case AggregateKind.Enum when definition.Fields.Count(f => f.ConstantValue == field.ConstantValue) > 1:
                         {
                             throw new InvalidFieldException(field, "Enum value must be unique");

--- a/Core/Meta/Field.cs
+++ b/Core/Meta/Field.cs
@@ -10,7 +10,7 @@ namespace Core.Meta
             in TypeBase type,
             in Span span,
             in BaseAttribute? deprecatedAttribute,
-            in int constantValue, string documentation)
+            in uint constantValue, string documentation)
         {
             Name = name;
             Type = type;
@@ -27,7 +27,7 @@ namespace Core.Meta
         /// <summary>
         /// For enums, this is a constant value. For messages, this is a field index. For structs, this is unused.
         /// </summary>
-        public int ConstantValue { get; }
+        public uint ConstantValue { get; }
         public string Documentation { get; }
     }
 }

--- a/Core/Meta/Interfaces/IField.cs
+++ b/Core/Meta/Interfaces/IField.cs
@@ -37,7 +37,7 @@ namespace Core.Meta.Interfaces
         ///     <see cref="AggregateKind.Message"/> a unique index.
         ///     It will be zero for <see cref="AggregateKind.Struct"/>.
         /// </remarks>
-        public int ConstantValue { get; }
+        public uint ConstantValue { get; }
 
         /// <summary>
         /// The inner text of a block comment that preceded the field.


### PR DESCRIPTION
This changes allows hex values to be used as constants. It also introduces checks to ensure there are not multiple definitions with the same name.