### PR TITLE
Throw when decoding an unrecognized union discriminator

### DIFF
--- a/Core/Generators/TypeScript/TypeScriptGenerator.cs
+++ b/Core/Generators/TypeScript/TypeScriptGenerator.cs
@@ -240,7 +240,7 @@ namespace Core.Generators.TypeScript
             }
             builder.AppendLine("  default:");
             builder.AppendLine("    view.index = end;");
-            builder.AppendLine("    return undefined;");
+            builder.AppendLine($"    throw new BebopRuntimeError(\"Unrecognized discriminator while decoding {definition.Name}\");");
             builder.AppendLine("}");
             return builder.ToString();
         }
@@ -339,7 +339,7 @@ namespace Core.Generators.TypeScript
         public override string Compile()
         {
             var builder = new IndentedStringBuilder();
-            builder.AppendLine("import { BebopView } from \"bebop\";");
+            builder.AppendLine("import { BebopView, BebopRuntimeError } from \"bebop\";");
             builder.AppendLine("");
             if (!string.IsNullOrWhiteSpace(Schema.Namespace))
             {

--- a/Runtime/TypeScript/index.ts
+++ b/Runtime/TypeScript/index.ts
@@ -24,6 +24,13 @@ if (typeof require !== 'undefined') {
     if (typeof TextDecoder === 'undefined') (global as any).TextDecoder = require('util').TextDecoder;
 }
 
+export class BebopRuntimeError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "BebopRuntimeError";
+    }
+}
+
 export class BebopView {
     private static textDecoder = new TextDecoder;
     private static writeBuffer: Uint8Array = new Uint8Array(256);


### PR DESCRIPTION
This adds a `BebopRuntimeError` type to the runtime, and throws that when decoding a union fails.

Tested with:

```
(cd Runtime/TypeScript && npm run build)
(cd Laboratory/TypeScript && ./compile-schemas.sh && npm install && npx jest)
```

It still works A-OK.