### PR TITLE
Unify union length calculation

### DIFF
--- a/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
+++ b/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
@@ -78,9 +78,9 @@ namespace Core.Generators.CPlusPlus
         {
             var builder = new IndentedStringBuilder(4);
             builder.AppendLine($"const auto pos = writer.reserveMessageLength();");
-            builder.AppendLine($"const auto start = writer.length();");
             builder.AppendLine($"const uint8_t discriminator = message.variant.index() + 1;");
             builder.AppendLine($"writer.writeByte(discriminator);");
+            builder.AppendLine($"const auto start = writer.length();");
             builder.AppendLine($"switch (discriminator) {{");
             foreach (var branch in definition.Branches)
             {
@@ -204,7 +204,7 @@ namespace Core.Generators.CPlusPlus
         {
             var builder = new IndentedStringBuilder(4);
             builder.AppendLine("const auto length = reader.readMessageLength();");
-            builder.AppendLine("const auto end = reader.pointer() + length;");
+            builder.AppendLine("const auto end = reader.pointer() + length + 1;");
             builder.AppendLine("switch (reader.readByte()) {");
             foreach (var branch in definition.Branches)
             {

--- a/Core/Generators/CSharp/CSharpGenerator.cs
+++ b/Core/Generators/CSharp/CSharpGenerator.cs
@@ -692,7 +692,7 @@ namespace Core.Generators.CSharp
         {
             var builder = new IndentedStringBuilder();
             builder.AppendLine("var length = reader.ReadRecordLength();");
-            builder.AppendLine("var end = unchecked((int) (reader.Position + length));");
+            builder.AppendLine("var end = unchecked((int) (reader.Position + length + 1));");
             builder.AppendLine("switch (reader.ReadByte()) {").Indent(indentStep);
             foreach (var branch in definition.Branches)
             {

--- a/Core/Generators/TypeScript/TypeScriptGenerator.cs
+++ b/Core/Generators/TypeScript/TypeScriptGenerator.cs
@@ -98,11 +98,11 @@ namespace Core.Generators.TypeScript
             var builder = new IndentedStringBuilder(6);
             builder.AppendLine($"const pos = view.reserveMessageLength();");
             builder.AppendLine($"const start = view.length + 1;");
+            builder.AppendLine($"view.writeByte(message.discriminator);");
             builder.AppendLine($"switch (message.discriminator) {{");
             foreach (var branch in definition.Branches)
             {
-                builder.AppendLine($"  case '{branch.Definition.Name}':");
-                builder.AppendLine($"    view.writeByte({branch.Discriminator});");
+                builder.AppendLine($"  case {branch.Discriminator}:");
                 builder.AppendLine($"    {branch.Definition.Name}.encodeInto(message.value, view);");
                 builder.AppendLine($"    break;");
             }
@@ -238,7 +238,7 @@ namespace Core.Generators.TypeScript
             foreach (var branch in definition.Branches)
             {
                 builder.AppendLine($"  case {branch.Discriminator}:");
-                builder.AppendLine($"    return {{ discriminator: '{branch.Definition.Name}', value: {branch.Definition.Name}.readFrom(view) }};");
+                builder.AppendLine($"    return {{ discriminator: {branch.Discriminator}, value: {branch.Definition.Name}.readFrom(view) }};");
             }
             builder.AppendLine("  default:");
             builder.AppendLine("    view.index = end;");
@@ -399,7 +399,7 @@ namespace Core.Generators.TypeScript
                     }
                     else if (definition is UnionDefinition ud)
                     {
-                        var expression = string.Join("\n  | ", ud.Branches.Select(b => $"{{ discriminator: '{b.Definition.Name}', value: I{b.Definition.Name} }}"));
+                        var expression = string.Join("\n  | ", ud.Branches.Select(b => $"{{ discriminator: {b.Discriminator}, value: I{b.Definition.Name} }}"));
                         if (string.IsNullOrWhiteSpace(expression)) expression = "never";
                         builder.AppendLine($"export type I{ud.Name}\n  = {expression};");
                         builder.AppendLine("");

--- a/Core/Generators/TypeScript/TypeScriptGenerator.cs
+++ b/Core/Generators/TypeScript/TypeScriptGenerator.cs
@@ -410,6 +410,11 @@ namespace Core.Generators.TypeScript
                     {
                         builder.AppendLine($"  opcode: {td.OpcodeAttribute.Value},");
                     }
+                    if (td.DiscriminatorInParent != null)
+                    {
+                        // We codegen "1 as 1", "2 as 2"... because TypeScript otherwise infers the type "number" for this field, whereas a literal type is necessary to discriminate unions.
+                        builder.AppendLine($"  discriminator: {td.DiscriminatorInParent} as {td.DiscriminatorInParent},");
+                    }
                     builder.AppendLine($"  encode(message: I{td.Name}): Uint8Array {{");
                     builder.AppendLine("    const view = BebopView.getInstance();");
                     builder.AppendLine("    view.startWriting();");

--- a/Core/Meta/Definition.cs
+++ b/Core/Meta/Definition.cs
@@ -44,6 +44,12 @@ namespace Core.Meta
         }
 
         public BaseAttribute? OpcodeAttribute { get; }
+
+        /// <summary>
+        /// If this definition is part of a union branch, then this is its discriminator in the parent union.
+        /// Otherwise, this property is null. (This feels a bit hacky, but oh well.)
+        /// </summary>
+        public byte? DiscriminatorInParent { get; set; }
     }
 
     /// <summary>

--- a/Core/Parser/SchemaParser.cs
+++ b/Core/Parser/SchemaParser.cs
@@ -392,17 +392,18 @@ namespace Core.Parser
                 Expect(TokenKind.Hyphen, hint: indexHint);
                 Expect(TokenKind.CloseCaret, hint: indexHint);
                 var definition = ParseDefinition();
-                if (definition is not TopLevelDefinition)
+                if (definition is not TopLevelDefinition td)
                 {
                     throw new InvalidUnionBranchException(definition);
                 }
+                td.DiscriminatorInParent = (byte)discriminator;
                 Eat(TokenKind.Semicolon);
                 definitionEnd = CurrentToken.Span;
                 if (string.IsNullOrWhiteSpace(definition.Documentation))
                 {
                     definition.Documentation = documentation;
                 }
-                branches.Add(new UnionBranch((byte)discriminator, (TopLevelDefinition)definition));
+                branches.Add(new UnionBranch((byte)discriminator, td));
             }
             var definitionSpan = definitionToken.Span.Combine(definitionEnd);
             var unionDefinition = new UnionDefinition(name, definitionSpan, definitionDocumentation, opcodeAttribute, branches);

--- a/Laboratory/Integration/UnionTypes/.gitignore
+++ b/Laboratory/Integration/UnionTypes/.gitignore
@@ -1,0 +1,5 @@
+union1.cs
+union1.hpp
+union1.ts
+bebop.hpp
+*.enc

--- a/Laboratory/Integration/UnionTypes/Program.cs
+++ b/Laboratory/Integration/UnionTypes/Program.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+
+namespace UnionTypes
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            if (args.Length == 1 && args[0] == "encode")
+            {
+                Union1 u = new Right("Success");
+                byte[] buffer = Union1.Encode(u);
+                using (var stdout = Console.OpenStandardOutput())
+                {
+                    stdout.Write(buffer, 0, buffer.Length);
+                }
+                return 0;
+            }
+            else if (args.Length == 2 && args[0] == "decode")
+            {
+                byte[] buffer = File.ReadAllBytes(args[1]);
+                Union1 u = Union1.Decode(buffer);
+                return (u.Value is Right r && r.R == "Success") ? 0 : 1;
+            }
+            else
+            {
+                var name = Environment.GetCommandLineArgs()[0];
+                Console.WriteLine($"Usage:\n  {name} encode\n  {name} decode file.buf");
+                return 1;
+            }
+        }
+    }
+}

--- a/Laboratory/Integration/UnionTypes/README.md
+++ b/Laboratory/Integration/UnionTypes/README.md
@@ -1,0 +1,6 @@
+This test checks that:
+
+* `Right(r="Success")` encodes to the same binary in all implementations.
+* All implementations decode that binary to `Right(r="Success")`.
+
+Run it with `./run_test.sh` (needs npm and dotnet).

--- a/Laboratory/Integration/UnionTypes/UnionTypes.csproj
+++ b/Laboratory/Integration/UnionTypes/UnionTypes.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Bebop">
+      <HintPath>..\..\..\Runtime\C#\bin\Debug\net5.0\Bebop.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/Laboratory/Integration/UnionTypes/decode.cpp
+++ b/Laboratory/Integration/UnionTypes/decode.cpp
@@ -1,0 +1,28 @@
+#include "union1.hpp"
+#include <cstdio>
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <variant>
+
+static std::vector<uint8_t> ReadAllBytes(char const *filename)
+{
+  std::ifstream ifs(filename, std::ios::binary | std::ios::ate);
+  std::ifstream::pos_type pos = ifs.tellg();
+  std::vector<uint8_t> result(pos);
+  ifs.seekg(0, std::ios::beg);
+  ifs.read(reinterpret_cast<char *>(&result[0]), pos);
+  return result;
+}
+
+int main(int argc, char **argv)
+{
+  const auto bytes = ReadAllBytes(argv[1]);
+  Union1 u;
+  Union1::decodeInto(bytes.data(), u);
+  auto right = std::get_if<Right>(&u.variant);
+  if (right != nullptr && right->r == "Success")
+    return 0;
+  else
+    return 1;
+}

--- a/Laboratory/Integration/UnionTypes/decode.ts
+++ b/Laboratory/Integration/UnionTypes/decode.ts
@@ -1,0 +1,10 @@
+import { Union1 } from "./union1";
+import fs = require("fs");
+
+const buffer = fs.readFileSync(process.argv[2]);
+const u = Union1.decode(buffer);
+if (u.discriminator === 2 && u.value.r === "Success") {
+  process.exit(0);
+} else {
+  process.exit(1);
+}

--- a/Laboratory/Integration/UnionTypes/decode.ts
+++ b/Laboratory/Integration/UnionTypes/decode.ts
@@ -1,9 +1,9 @@
-import { Union1 } from "./union1";
+import { Union1, Right } from "./union1";
 import fs = require("fs");
 
 const buffer = fs.readFileSync(process.argv[2]);
 const u = Union1.decode(buffer);
-if (u.discriminator === 2 && u.value.r === "Success") {
+if (u.discriminator === Right.discriminator && u.value.r === "Success") {
   process.exit(0);
 } else {
   process.exit(1);

--- a/Laboratory/Integration/UnionTypes/encode.cpp
+++ b/Laboratory/Integration/UnionTypes/encode.cpp
@@ -1,0 +1,13 @@
+#include "union1.hpp"
+#include <cstdio>
+#include <vector>
+
+int main()
+{
+  std::vector<uint8_t> buffer;
+  Union1 u;
+  u.variant = Right{"Success"};
+  Union1::encodeInto(u, buffer);
+  std::fwrite(buffer.data(), sizeof(uint8_t), buffer.size(), stdout);
+  return 0;
+}

--- a/Laboratory/Integration/UnionTypes/encode.csx
+++ b/Laboratory/Integration/UnionTypes/encode.csx
@@ -1,0 +1,4 @@
+#! "5.0.0-rc.2.20475.5"
+#r "../../../Runtime/C\#/bin/Debug/net5.0/Bebop.dll"
+using System;
+Console.WriteLine("ok");

--- a/Laboratory/Integration/UnionTypes/encode.csx
+++ b/Laboratory/Integration/UnionTypes/encode.csx
@@ -1,4 +1,0 @@
-#! "5.0.0-rc.2.20475.5"
-#r "../../../Runtime/C\#/bin/Debug/net5.0/Bebop.dll"
-using System;
-Console.WriteLine("ok");

--- a/Laboratory/Integration/UnionTypes/encode.ts
+++ b/Laboratory/Integration/UnionTypes/encode.ts
@@ -1,0 +1,5 @@
+import { Union1 } from "./union1";
+
+const buffer = Union1.encode({ discriminator: 2, value: { r: "Success" } });
+process.stdout.write(buffer);
+

--- a/Laboratory/Integration/UnionTypes/encode.ts
+++ b/Laboratory/Integration/UnionTypes/encode.ts
@@ -1,5 +1,5 @@
-import { Union1 } from "./union1";
+import { Union1, Right } from "./union1";
 
-const buffer = Union1.encode({ discriminator: 2, value: { r: "Success" } });
+const buffer = Union1.encode({ discriminator: Right.discriminator, value: { r: "Success" } });
 process.stdout.write(buffer);
 

--- a/Laboratory/Integration/UnionTypes/package-lock.json
+++ b/Laboratory/Integration/UnionTypes/package-lock.json
@@ -1,0 +1,197 @@
+{
+  "name": "UnionTypes",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@types/node": "^14.14.6",
+        "bebop": "file:../../../Runtime/TypeScript",
+        "ts-node": "^9.0.0",
+        "typescript": "^4.1.2"
+      }
+    },
+    "../../../Runtime/TypeScript": {
+      "name": "bebop",
+      "version": "2.0.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^14.14.7"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
+    "node_modules/bebop": {
+      "resolved": "../../../Runtime/TypeScript",
+      "link": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/node": {
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
+    "bebop": {
+      "version": "file:../../../Runtime/TypeScript",
+      "requires": {
+        "@types/node": "^14.14.7"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
+    "typescript": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+    }
+  }
+}

--- a/Laboratory/Integration/UnionTypes/package.json
+++ b/Laboratory/Integration/UnionTypes/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@types/node": "^14.14.6",
+    "bebop": "file:../../../Runtime/TypeScript",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.1.2"
+  }
+}

--- a/Laboratory/Integration/UnionTypes/run_test.sh
+++ b/Laboratory/Integration/UnionTypes/run_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+echo "Compiling schema..."
+dotnet run --project ../../../Compiler --files union1.bop --cs union1.cs --ts union1.ts --cpp union1.hpp
+echo "Running npm install..."
+npm install
+
+echo "Testing that all implementations agree on encoding..."
+dotnet run encode > cs.enc
+npx ts-node encode.ts > ts.enc
+(g++ --std=c++17 encode.cpp && ./a.out) > cpp.enc
+rm -f ./a.out
+
+failed=0
+fail() { echo -e "\033[1;31m$1\033[0m"; failed=1; }
+
+cmp cs.enc ts.enc || fail "C# and TypeScript encodes differ."
+cmp cs.enc cpp.enc || fail "C# and C++ encodes differ."
+
+echo "Testing that all implementations can decode the buffer agreed on..."
+dotnet run decode cs.enc || fail "C# decode failed."
+npx ts-node decode.ts cs.enc || fail "TypeScript decode failed."
+(g++ --std=c++17 decode.cpp && ./a.out cs.enc) || fail "C++ decode failed."
+rm -f ./a.out
+
+if [ "$failed" = "0" ]; then
+  echo -e "\033[32mAll tests passed.\033[0m"
+fi

--- a/Laboratory/Integration/UnionTypes/union1.bop
+++ b/Laboratory/Integration/UnionTypes/union1.bop
@@ -1,0 +1,4 @@
+union Union1 {
+  1 -> struct Left { uint32 l; }
+  2 -> struct Right { string r; }
+}

--- a/Laboratory/TypeScript/test/union.ts
+++ b/Laboratory/TypeScript/test/union.ts
@@ -4,7 +4,7 @@ import * as assert from "assert";
 
 it("Union roundtrip", () => {
     const obj: IU = {
-        discriminator: 'A',
+        discriminator: 1,
         value: { a: 12345 },
     };
     const bytes = U.encode(obj);

--- a/Laboratory/TypeScript/test/union.ts
+++ b/Laboratory/TypeScript/test/union.ts
@@ -1,0 +1,14 @@
+import { BebopView } from 'bebop';
+import { IU, U } from './generated/union';
+import * as assert from "assert";
+
+it("Union roundtrip", () => {
+    const obj: IU = {
+        discriminator: 'A',
+        value: { a: 12345 },
+    };
+    const bytes = U.encode(obj);
+    const obj2 = U.decode(bytes);
+    expect(obj).toEqual(obj2);
+});
+


### PR DESCRIPTION
Our generated code was inconsistent about whether the discriminator byte was counted as part of the `length` field in the union wire format.

This makes it so that the discriminator byte is uniformly **not** counted everywhere in the codegen. The length field is the length of the encoded body that _follows_ the discriminator byte.