### PR TITLE
feature stacked byte schemes :sparkles:

### DIFF
--- a/Runtime/Dart/lib/bebop_dart.dart
+++ b/Runtime/Dart/lib/bebop_dart.dart
@@ -6,4 +6,3 @@
 library bebop_dart;
 
 export 'src/bebop.dart';
-

--- a/Runtime/Dart/lib/src/bebop.dart
+++ b/Runtime/Dart/lib/src/bebop.dart
@@ -170,9 +170,7 @@ class BebopWriter {
 
   void _guaranteeBufferLength(int length) {
     if (length > _bytes.lengthInBytes) {
-      // ensure data is big enough if we deal with huge buffers
-      final data =
-          Uint8List(min(max(2 * _bytes.lengthInBytes, length), length));
+      final data = Uint8List(max(2 * _bytes.lengthInBytes, length));
       data.setAll(0, _bytes);
       _bytes = data;
       _buffer = data.buffer;

--- a/Runtime/Dart/lib/src/bebop.dart
+++ b/Runtime/Dart/lib/src/bebop.dart
@@ -8,7 +8,6 @@ import 'tables.dart';
 /// It is used by the code that `bebopc --lang dart` generates. You shouldn't
 /// need to use it directly.
 class BebopReader {
-  ByteBuffer _buffer;
   Uint8List _bytes;
   ByteData _view;
   int index = 0;
@@ -19,13 +18,12 @@ class BebopReader {
 
   BebopReader._();
   static final BebopReader _instance = BebopReader._();
-  factory BebopReader.fromBuffer(ByteBuffer buffer) => _instance..load(buffer);
-  factory BebopReader(Uint8List list) => BebopReader.fromBuffer(list.buffer);
+  factory BebopReader(Uint8List list) => _instance..load(list);
 
-  void load(ByteBuffer buffer) {
-    _buffer = buffer;
-    _bytes = Uint8List.view(buffer);
-    _view = ByteData.view(_buffer);
+  void load(Uint8List list) {
+    // copy to new list cause underlying buffer seems to have some offset; see https://stackoverflow.com/questions/53897530/unreadable-int16-from-uint8list-wrong-data-when-cast-asbytearray
+    _bytes = Uint8List.fromList(list);
+    _view = ByteData.view(_bytes.buffer);
     index = 0;
   }
 
@@ -90,7 +88,7 @@ class BebopReader {
     if (length == 0) {
       return _emptyByteList;
     }
-    final view = _buffer.asUint8List(index, length);
+    final view = _bytes.sublist(index, index + length);
     index += length;
     return view;
   }
@@ -100,7 +98,7 @@ class BebopReader {
     if (length == 0) {
       return _emptyString;
     }
-    final view = _buffer.asUint8List(index, length);
+    final view = _bytes.sublist(index, index + length);
     index += length;
     return _utf8Decoder.convert(view);
   }
@@ -153,7 +151,7 @@ class BebopWriter {
   ByteData _view;
   int length = 0;
 
-static const Utf8Encoder _utf8Encoder = Utf8Encoder();
+  static const Utf8Encoder _utf8Encoder = Utf8Encoder();
 
   BebopWriter._() {
     _buffer = _bytes.buffer;
@@ -161,11 +159,20 @@ static const Utf8Encoder _utf8Encoder = Utf8Encoder();
   }
 
   static final BebopWriter _instance = BebopWriter._();
-  factory BebopWriter() => _instance..length = 0;
+  factory BebopWriter() {
+    // clear buffer -> enables stacked byte schemes
+    _instance._bytes = Uint8List(256);
+    _instance._buffer = _instance._bytes.buffer;
+    _instance._view = ByteData.view(_instance._buffer);
+    _instance.length = 0;
+    return _instance;
+  }
 
   void _guaranteeBufferLength(int length) {
     if (length > _bytes.lengthInBytes) {
-      final data = Uint8List(min(2 * _bytes.lengthInBytes, length));
+      // ensure data is big enough if we deal with huge buffers
+      final data =
+          Uint8List(min(max(2 * _bytes.lengthInBytes, length), length));
       data.setAll(0, _bytes);
       _bytes = data;
       _buffer = data.buffer;
@@ -246,7 +253,7 @@ static const Utf8Encoder _utf8Encoder = Utf8Encoder();
   }
 
   void writeString(String value) {
-    if (value.length == 0) {
+    if (value.isEmpty) {
       writeUint32(0);
       return;
     }

--- a/Runtime/Dart/lib/stacked_schemes.g.dart
+++ b/Runtime/Dart/lib/stacked_schemes.g.dart
@@ -1,0 +1,54 @@
+import 'dart:typed_data';
+import 'package:meta/meta.dart';
+import 'package:bebop_dart/bebop_dart.dart';
+
+class Schema1 {
+  String prop1;
+  Schema1({
+    @required this.prop1,
+  });
+
+  static Uint8List encode(Schema1 message) {
+    final writer = BebopWriter();
+    Schema1.encodeInto(message, writer);
+    return writer.toList();
+  }
+
+  static void encodeInto(Schema1 message, BebopWriter view) {
+    view.writeString(message.prop1);
+  }
+
+  static Schema1 decode(Uint8List buffer) => Schema1.readFrom(BebopReader(buffer));
+
+  static Schema1 readFrom(BebopReader view) {
+    String field0;
+    field0 = view.readString();
+    return Schema1(prop1: field0);
+  }
+}
+
+class Schema2 {
+  Uint8List schemaBytes;
+  Schema2({
+    @required this.schemaBytes,
+  });
+
+  static Uint8List encode(Schema2 message) {
+    final writer = BebopWriter();
+    Schema2.encodeInto(message, writer);
+    return writer.toList();
+  }
+
+  static void encodeInto(Schema2 message, BebopWriter view) {
+    view.writeBytes(message.schemaBytes);
+  }
+
+  static Schema2 decode(Uint8List buffer) => Schema2.readFrom(BebopReader(buffer));
+
+  static Schema2 readFrom(BebopReader view) {
+    Uint8List field0;
+    field0 = view.readBytes();
+    return Schema2(schemaBytes: field0);
+  }
+}
+

--- a/Runtime/Dart/stackedSchemes/Schema1.bop
+++ b/Runtime/Dart/stackedSchemes/Schema1.bop
@@ -1,0 +1,3 @@
+struct Schema1 {
+    string prop1;
+}

--- a/Runtime/Dart/stackedSchemes/Schema2.bop
+++ b/Runtime/Dart/stackedSchemes/Schema2.bop
@@ -1,0 +1,3 @@
+struct Schema2 {
+    byte[] schemaBytes;
+}

--- a/Runtime/Dart/test/bebop_dart_test.dart
+++ b/Runtime/Dart/test/bebop_dart_test.dart
@@ -1,4 +1,5 @@
 import 'package:bebop_dart/bebop_dart.dart';
+import 'package:bebop_dart/stacked_schemes.g.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -48,6 +49,18 @@ void main() {
       expect(list, hasLength(16));
       reader = BebopReader(list);
       expect(reader.readGuid(), equals(guid));
+    });
+
+    test('Stacked schemes', () {
+      var scheme1 = Schema1(prop1: "Hi I'm stacked");
+      var scheme2 = Schema2(schemaBytes: Schema1.encode(scheme1));
+
+      var bytes = Schema2.encode(scheme2);
+      var restored2 = Schema2.decode(bytes);
+      expect(restored2.schemaBytes, isNotNull);
+
+      var restored1 = Schema1.decode(restored2.schemaBytes);
+      expect(restored1.prop1, equals("Hi I'm stacked"));
     });
   });
 }


### PR DESCRIPTION
Hey guys I faced some issues when I wanted to implement the [mirroring network pattern](https://github.com/RainwayApp/bebop/wiki/Getting-Started-with-.NET) in dart. I made some changes to writer and reader that fixed this for me. Hope those help you out :)
If you want to reproduce my errors just exchange `bebop_dart.dart` with the current implementation and run the new test case.

Changes include:
- changed bebop writer to allow stacked byte schemes by clearing buffer
- fixed bebop reader byte buffer bug
- fixed bebop writer guaranteeBufferLength ensuring large enough buffers
- added test to validate byte stackability