### PR TITLE
C++: throw instead of crashing on invalid data

### DIFF
--- a/Laboratory/C++/gen/jazz.hpp
+++ b/Laboratory/C++/gen/jazz.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -14,11 +15,17 @@ enum class Instrument {
   Clarinet = 2,
 };
 
+/// test
 struct Musician {
+  static const size_t minimalEncodedSize = 8;
+  static const uint32_t opcode = 0x5A5A414A;
+
+  /// a name
   std::string name;
+  /// an instrument
   Instrument plays;
 
-  static void encodeInto(const Musician& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const Musician& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     Musician::encodeInto(message, writer);
   }
@@ -28,15 +35,29 @@ struct Musician {
     writer.writeUint32(static_cast<uint32_t>(message.plays));
   }
 
-  static Musician decode(const uint8_t *sourceBuffer) {
+  static Musician decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     Musician result;
-    Musician::decodeInto(sourceBuffer, result);
+    Musician::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, Musician& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static Musician decode(std::vector<uint8_t> sourceBuffer) {
+    return Musician::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static Musician decode(::bebop::Reader& reader) {
+    Musician result;
+    Musician::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, Musician& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     Musician::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, Musician& target) {
+    Musician::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, Musician& target) {
@@ -46,11 +67,12 @@ struct Musician {
 };
 
 struct Song {
+  static const size_t minimalEncodedSize = 4;
   std::optional<std::string> title;
   std::optional<uint16_t> year;
   std::optional<std::vector<Musician>> performers;
 
-  static void encodeInto(const Song& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const Song& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     Song::encodeInto(message, writer);
   }
@@ -81,19 +103,33 @@ struct Song {
     writer.fillMessageLength(pos, end - start);
   }
 
-  static Song decode(const uint8_t *sourceBuffer) {
+  static Song decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     Song result;
-    Song::decodeInto(sourceBuffer, result);
+    Song::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, Song& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static Song decode(std::vector<uint8_t> sourceBuffer) {
+    return Song::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static Song decode(::bebop::Reader& reader) {
+    Song result;
+    Song::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, Song& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     Song::decodeInto(reader, target);
   }
 
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, Song& target) {
+    Song::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
+  }
+
   static void decodeInto(::bebop::Reader& reader, Song& target) {
-    const auto length = reader.readMessageLength();
+    const auto length = reader.readLengthPrefix();
     const auto end = reader.pointer() + length;
     while (true) {
       switch (reader.readByte()) {
@@ -126,9 +162,10 @@ struct Song {
 };
 
 struct Library {
+  static const size_t minimalEncodedSize = 4;
   std::map<::bebop::Guid, Song> songs;
 
-  static void encodeInto(const Library& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const Library& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     Library::encodeInto(message, writer);
   }
@@ -141,15 +178,29 @@ struct Library {
     }
   }
 
-  static Library decode(const uint8_t *sourceBuffer) {
+  static Library decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     Library result;
-    Library::decodeInto(sourceBuffer, result);
+    Library::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, Library& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static Library decode(std::vector<uint8_t> sourceBuffer) {
+    return Library::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static Library decode(::bebop::Reader& reader) {
+    Library result;
+    Library::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, Library& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     Library::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, Library& target) {
+    Library::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, Library& target) {

--- a/Laboratory/C++/gen/nested_message.hpp
+++ b/Laboratory/C++/gen/nested_message.hpp
@@ -10,6 +10,7 @@
 #include "bebop.hpp"
 
 struct InnerM {
+  static const size_t minimalEncodedSize = 4;
   std::optional<int32_t> x;
 
   static void encodeInto(const InnerM& message, std::vector<uint8_t>& targetBuffer) {
@@ -29,10 +30,14 @@ struct InnerM {
     writer.fillMessageLength(pos, end - start);
   }
 
-  static InnerM decode(const uint8_t* sourceBuffer) {
+  static InnerM decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     InnerM result;
-    InnerM::decodeInto(sourceBuffer, result);
+    InnerM::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
+  }
+
+  static InnerM decode(std::vector<uint8_t> sourceBuffer) {
+    return InnerM::decode(sourceBuffer.data(), sourceBuffer.size());
   }
 
   static InnerM decode(::bebop::Reader& reader) {
@@ -41,13 +46,17 @@ struct InnerM {
     return result;
   }
 
-  static void decodeInto(const uint8_t* sourceBuffer, InnerM& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, InnerM& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     InnerM::decodeInto(reader, target);
   }
 
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, InnerM& target) {
+    InnerM::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
+  }
+
   static void decodeInto(::bebop::Reader& reader, InnerM& target) {
-    const auto length = reader.readMessageLength();
+    const auto length = reader.readLengthPrefix();
     const auto end = reader.pointer() + length;
     while (true) {
       switch (reader.readByte()) {
@@ -65,6 +74,7 @@ struct InnerM {
 };
 
 struct InnerS {
+  static const size_t minimalEncodedSize = 1;
   bool y;
 
   static void encodeInto(const InnerS& message, std::vector<uint8_t>& targetBuffer) {
@@ -76,10 +86,14 @@ struct InnerS {
     writer.writeBool(message.y);
   }
 
-  static InnerS decode(const uint8_t* sourceBuffer) {
+  static InnerS decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     InnerS result;
-    InnerS::decodeInto(sourceBuffer, result);
+    InnerS::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
+  }
+
+  static InnerS decode(std::vector<uint8_t> sourceBuffer) {
+    return InnerS::decode(sourceBuffer.data(), sourceBuffer.size());
   }
 
   static InnerS decode(::bebop::Reader& reader) {
@@ -88,9 +102,13 @@ struct InnerS {
     return result;
   }
 
-  static void decodeInto(const uint8_t* sourceBuffer, InnerS& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, InnerS& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     InnerS::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, InnerS& target) {
+    InnerS::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, InnerS& target) {
@@ -99,6 +117,7 @@ struct InnerS {
 };
 
 struct OuterM {
+  static const size_t minimalEncodedSize = 4;
   std::optional<InnerM> innerM;
   std::optional<InnerS> innerS;
 
@@ -123,10 +142,14 @@ struct OuterM {
     writer.fillMessageLength(pos, end - start);
   }
 
-  static OuterM decode(const uint8_t* sourceBuffer) {
+  static OuterM decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     OuterM result;
-    OuterM::decodeInto(sourceBuffer, result);
+    OuterM::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
+  }
+
+  static OuterM decode(std::vector<uint8_t> sourceBuffer) {
+    return OuterM::decode(sourceBuffer.data(), sourceBuffer.size());
   }
 
   static OuterM decode(::bebop::Reader& reader) {
@@ -135,13 +158,17 @@ struct OuterM {
     return result;
   }
 
-  static void decodeInto(const uint8_t* sourceBuffer, OuterM& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, OuterM& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     OuterM::decodeInto(reader, target);
   }
 
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, OuterM& target) {
+    OuterM::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
+  }
+
   static void decodeInto(::bebop::Reader& reader, OuterM& target) {
-    const auto length = reader.readMessageLength();
+    const auto length = reader.readLengthPrefix();
     const auto end = reader.pointer() + length;
     while (true) {
       switch (reader.readByte()) {
@@ -162,6 +189,7 @@ struct OuterM {
 };
 
 struct OuterS {
+  static const size_t minimalEncodedSize = 5;
   InnerM innerM;
   InnerS innerS;
 
@@ -175,10 +203,14 @@ struct OuterS {
     InnerS::encodeInto(message.innerS, writer);
   }
 
-  static OuterS decode(const uint8_t* sourceBuffer) {
+  static OuterS decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     OuterS result;
-    OuterS::decodeInto(sourceBuffer, result);
+    OuterS::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
+  }
+
+  static OuterS decode(std::vector<uint8_t> sourceBuffer) {
+    return OuterS::decode(sourceBuffer.data(), sourceBuffer.size());
   }
 
   static OuterS decode(::bebop::Reader& reader) {
@@ -187,9 +219,13 @@ struct OuterS {
     return result;
   }
 
-  static void decodeInto(const uint8_t* sourceBuffer, OuterS& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, OuterS& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     OuterS::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, OuterS& target) {
+    OuterS::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, OuterS& target) {

--- a/Laboratory/C++/gen/union_perf_a.hpp
+++ b/Laboratory/C++/gen/union_perf_a.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -9,6 +10,7 @@
 #include "bebop.hpp"
 
 struct A1 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i1;
   uint64_t u;
   double f;
@@ -16,7 +18,7 @@ struct A1 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A1& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A1& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A1::encodeInto(message, writer);
   }
@@ -30,15 +32,29 @@ struct A1 {
     writer.writeBool(message.b);
   }
 
-  static A1 decode(const uint8_t *sourceBuffer) {
+  static A1 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A1 result;
-    A1::decodeInto(sourceBuffer, result);
+    A1::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A1& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A1 decode(std::vector<uint8_t> sourceBuffer) {
+    return A1::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A1 decode(::bebop::Reader& reader) {
+    A1 result;
+    A1::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A1& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A1::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A1& target) {
+    A1::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A1& target) {
@@ -52,6 +68,7 @@ struct A1 {
 };
 
 struct A2 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i2;
   uint64_t u;
   double f;
@@ -59,7 +76,7 @@ struct A2 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A2& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A2& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A2::encodeInto(message, writer);
   }
@@ -73,15 +90,29 @@ struct A2 {
     writer.writeBool(message.b);
   }
 
-  static A2 decode(const uint8_t *sourceBuffer) {
+  static A2 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A2 result;
-    A2::decodeInto(sourceBuffer, result);
+    A2::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A2& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A2 decode(std::vector<uint8_t> sourceBuffer) {
+    return A2::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A2 decode(::bebop::Reader& reader) {
+    A2 result;
+    A2::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A2& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A2::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A2& target) {
+    A2::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A2& target) {
@@ -95,6 +126,7 @@ struct A2 {
 };
 
 struct A3 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i3;
   uint64_t u;
   double f;
@@ -102,7 +134,7 @@ struct A3 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A3& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A3& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A3::encodeInto(message, writer);
   }
@@ -116,15 +148,29 @@ struct A3 {
     writer.writeBool(message.b);
   }
 
-  static A3 decode(const uint8_t *sourceBuffer) {
+  static A3 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A3 result;
-    A3::decodeInto(sourceBuffer, result);
+    A3::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A3& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A3 decode(std::vector<uint8_t> sourceBuffer) {
+    return A3::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A3 decode(::bebop::Reader& reader) {
+    A3 result;
+    A3::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A3& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A3::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A3& target) {
+    A3::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A3& target) {
@@ -138,6 +184,7 @@ struct A3 {
 };
 
 struct A4 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i4;
   uint64_t u;
   double f;
@@ -145,7 +192,7 @@ struct A4 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A4& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A4& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A4::encodeInto(message, writer);
   }
@@ -159,15 +206,29 @@ struct A4 {
     writer.writeBool(message.b);
   }
 
-  static A4 decode(const uint8_t *sourceBuffer) {
+  static A4 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A4 result;
-    A4::decodeInto(sourceBuffer, result);
+    A4::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A4& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A4 decode(std::vector<uint8_t> sourceBuffer) {
+    return A4::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A4 decode(::bebop::Reader& reader) {
+    A4 result;
+    A4::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A4& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A4::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A4& target) {
+    A4::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A4& target) {
@@ -181,6 +242,7 @@ struct A4 {
 };
 
 struct A5 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i5;
   uint64_t u;
   double f;
@@ -188,7 +250,7 @@ struct A5 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A5& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A5& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A5::encodeInto(message, writer);
   }
@@ -202,15 +264,29 @@ struct A5 {
     writer.writeBool(message.b);
   }
 
-  static A5 decode(const uint8_t *sourceBuffer) {
+  static A5 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A5 result;
-    A5::decodeInto(sourceBuffer, result);
+    A5::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A5& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A5 decode(std::vector<uint8_t> sourceBuffer) {
+    return A5::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A5 decode(::bebop::Reader& reader) {
+    A5 result;
+    A5::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A5& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A5::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A5& target) {
+    A5::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A5& target) {
@@ -224,6 +300,7 @@ struct A5 {
 };
 
 struct A6 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i6;
   uint64_t u;
   double f;
@@ -231,7 +308,7 @@ struct A6 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A6& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A6& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A6::encodeInto(message, writer);
   }
@@ -245,15 +322,29 @@ struct A6 {
     writer.writeBool(message.b);
   }
 
-  static A6 decode(const uint8_t *sourceBuffer) {
+  static A6 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A6 result;
-    A6::decodeInto(sourceBuffer, result);
+    A6::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A6& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A6 decode(std::vector<uint8_t> sourceBuffer) {
+    return A6::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A6 decode(::bebop::Reader& reader) {
+    A6 result;
+    A6::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A6& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A6::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A6& target) {
+    A6::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A6& target) {
@@ -267,6 +358,7 @@ struct A6 {
 };
 
 struct A7 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i7;
   uint64_t u;
   double f;
@@ -274,7 +366,7 @@ struct A7 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A7& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A7& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A7::encodeInto(message, writer);
   }
@@ -288,15 +380,29 @@ struct A7 {
     writer.writeBool(message.b);
   }
 
-  static A7 decode(const uint8_t *sourceBuffer) {
+  static A7 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A7 result;
-    A7::decodeInto(sourceBuffer, result);
+    A7::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A7& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A7 decode(std::vector<uint8_t> sourceBuffer) {
+    return A7::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A7 decode(::bebop::Reader& reader) {
+    A7 result;
+    A7::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A7& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A7::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A7& target) {
+    A7::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A7& target) {
@@ -310,6 +416,7 @@ struct A7 {
 };
 
 struct A8 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i8;
   uint64_t u;
   double f;
@@ -317,7 +424,7 @@ struct A8 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A8& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A8& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A8::encodeInto(message, writer);
   }
@@ -331,15 +438,29 @@ struct A8 {
     writer.writeBool(message.b);
   }
 
-  static A8 decode(const uint8_t *sourceBuffer) {
+  static A8 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A8 result;
-    A8::decodeInto(sourceBuffer, result);
+    A8::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A8& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A8 decode(std::vector<uint8_t> sourceBuffer) {
+    return A8::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A8 decode(::bebop::Reader& reader) {
+    A8 result;
+    A8::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A8& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A8::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A8& target) {
+    A8::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A8& target) {
@@ -353,6 +474,7 @@ struct A8 {
 };
 
 struct A9 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i9;
   uint64_t u;
   double f;
@@ -360,7 +482,7 @@ struct A9 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A9& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A9& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A9::encodeInto(message, writer);
   }
@@ -374,15 +496,29 @@ struct A9 {
     writer.writeBool(message.b);
   }
 
-  static A9 decode(const uint8_t *sourceBuffer) {
+  static A9 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A9 result;
-    A9::decodeInto(sourceBuffer, result);
+    A9::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A9& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A9 decode(std::vector<uint8_t> sourceBuffer) {
+    return A9::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A9 decode(::bebop::Reader& reader) {
+    A9 result;
+    A9::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A9& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A9::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A9& target) {
+    A9::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A9& target) {
@@ -396,6 +532,7 @@ struct A9 {
 };
 
 struct A10 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i10;
   uint64_t u;
   double f;
@@ -403,7 +540,7 @@ struct A10 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A10& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A10& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A10::encodeInto(message, writer);
   }
@@ -417,15 +554,29 @@ struct A10 {
     writer.writeBool(message.b);
   }
 
-  static A10 decode(const uint8_t *sourceBuffer) {
+  static A10 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A10 result;
-    A10::decodeInto(sourceBuffer, result);
+    A10::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A10& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A10 decode(std::vector<uint8_t> sourceBuffer) {
+    return A10::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A10 decode(::bebop::Reader& reader) {
+    A10 result;
+    A10::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A10& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A10::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A10& target) {
+    A10::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A10& target) {
@@ -439,6 +590,7 @@ struct A10 {
 };
 
 struct A11 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i11;
   uint64_t u;
   double f;
@@ -446,7 +598,7 @@ struct A11 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A11& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A11& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A11::encodeInto(message, writer);
   }
@@ -460,15 +612,29 @@ struct A11 {
     writer.writeBool(message.b);
   }
 
-  static A11 decode(const uint8_t *sourceBuffer) {
+  static A11 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A11 result;
-    A11::decodeInto(sourceBuffer, result);
+    A11::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A11& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A11 decode(std::vector<uint8_t> sourceBuffer) {
+    return A11::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A11 decode(::bebop::Reader& reader) {
+    A11 result;
+    A11::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A11& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A11::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A11& target) {
+    A11::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A11& target) {
@@ -482,6 +648,7 @@ struct A11 {
 };
 
 struct A12 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i12;
   uint64_t u;
   double f;
@@ -489,7 +656,7 @@ struct A12 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A12& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A12& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A12::encodeInto(message, writer);
   }
@@ -503,15 +670,29 @@ struct A12 {
     writer.writeBool(message.b);
   }
 
-  static A12 decode(const uint8_t *sourceBuffer) {
+  static A12 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A12 result;
-    A12::decodeInto(sourceBuffer, result);
+    A12::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A12& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A12 decode(std::vector<uint8_t> sourceBuffer) {
+    return A12::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A12 decode(::bebop::Reader& reader) {
+    A12 result;
+    A12::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A12& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A12::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A12& target) {
+    A12::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A12& target) {
@@ -525,6 +706,7 @@ struct A12 {
 };
 
 struct A13 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i13;
   uint64_t u;
   double f;
@@ -532,7 +714,7 @@ struct A13 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A13& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A13& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A13::encodeInto(message, writer);
   }
@@ -546,15 +728,29 @@ struct A13 {
     writer.writeBool(message.b);
   }
 
-  static A13 decode(const uint8_t *sourceBuffer) {
+  static A13 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A13 result;
-    A13::decodeInto(sourceBuffer, result);
+    A13::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A13& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A13 decode(std::vector<uint8_t> sourceBuffer) {
+    return A13::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A13 decode(::bebop::Reader& reader) {
+    A13 result;
+    A13::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A13& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A13::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A13& target) {
+    A13::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A13& target) {
@@ -568,6 +764,7 @@ struct A13 {
 };
 
 struct A14 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i14;
   uint64_t u;
   double f;
@@ -575,7 +772,7 @@ struct A14 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A14& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A14& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A14::encodeInto(message, writer);
   }
@@ -589,15 +786,29 @@ struct A14 {
     writer.writeBool(message.b);
   }
 
-  static A14 decode(const uint8_t *sourceBuffer) {
+  static A14 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A14 result;
-    A14::decodeInto(sourceBuffer, result);
+    A14::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A14& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A14 decode(std::vector<uint8_t> sourceBuffer) {
+    return A14::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A14 decode(::bebop::Reader& reader) {
+    A14 result;
+    A14::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A14& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A14::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A14& target) {
+    A14::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A14& target) {
@@ -611,6 +822,7 @@ struct A14 {
 };
 
 struct A15 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i15;
   uint64_t u;
   double f;
@@ -618,7 +830,7 @@ struct A15 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A15& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A15& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A15::encodeInto(message, writer);
   }
@@ -632,15 +844,29 @@ struct A15 {
     writer.writeBool(message.b);
   }
 
-  static A15 decode(const uint8_t *sourceBuffer) {
+  static A15 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A15 result;
-    A15::decodeInto(sourceBuffer, result);
+    A15::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A15& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A15 decode(std::vector<uint8_t> sourceBuffer) {
+    return A15::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A15 decode(::bebop::Reader& reader) {
+    A15 result;
+    A15::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A15& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A15::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A15& target) {
+    A15::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A15& target) {
@@ -654,6 +880,7 @@ struct A15 {
 };
 
 struct A16 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i16;
   uint64_t u;
   double f;
@@ -661,7 +888,7 @@ struct A16 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A16& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A16& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A16::encodeInto(message, writer);
   }
@@ -675,15 +902,29 @@ struct A16 {
     writer.writeBool(message.b);
   }
 
-  static A16 decode(const uint8_t *sourceBuffer) {
+  static A16 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A16 result;
-    A16::decodeInto(sourceBuffer, result);
+    A16::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A16& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A16 decode(std::vector<uint8_t> sourceBuffer) {
+    return A16::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A16 decode(::bebop::Reader& reader) {
+    A16 result;
+    A16::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A16& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A16::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A16& target) {
+    A16::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A16& target) {
@@ -697,6 +938,7 @@ struct A16 {
 };
 
 struct A17 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i17;
   uint64_t u;
   double f;
@@ -704,7 +946,7 @@ struct A17 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A17& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A17& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A17::encodeInto(message, writer);
   }
@@ -718,15 +960,29 @@ struct A17 {
     writer.writeBool(message.b);
   }
 
-  static A17 decode(const uint8_t *sourceBuffer) {
+  static A17 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A17 result;
-    A17::decodeInto(sourceBuffer, result);
+    A17::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A17& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A17 decode(std::vector<uint8_t> sourceBuffer) {
+    return A17::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A17 decode(::bebop::Reader& reader) {
+    A17 result;
+    A17::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A17& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A17::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A17& target) {
+    A17::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A17& target) {
@@ -740,6 +996,7 @@ struct A17 {
 };
 
 struct A18 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i18;
   uint64_t u;
   double f;
@@ -747,7 +1004,7 @@ struct A18 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A18& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A18& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A18::encodeInto(message, writer);
   }
@@ -761,15 +1018,29 @@ struct A18 {
     writer.writeBool(message.b);
   }
 
-  static A18 decode(const uint8_t *sourceBuffer) {
+  static A18 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A18 result;
-    A18::decodeInto(sourceBuffer, result);
+    A18::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A18& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A18 decode(std::vector<uint8_t> sourceBuffer) {
+    return A18::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A18 decode(::bebop::Reader& reader) {
+    A18 result;
+    A18::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A18& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A18::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A18& target) {
+    A18::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A18& target) {
@@ -783,6 +1054,7 @@ struct A18 {
 };
 
 struct A19 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i19;
   uint64_t u;
   double f;
@@ -790,7 +1062,7 @@ struct A19 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A19& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A19& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A19::encodeInto(message, writer);
   }
@@ -804,15 +1076,29 @@ struct A19 {
     writer.writeBool(message.b);
   }
 
-  static A19 decode(const uint8_t *sourceBuffer) {
+  static A19 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A19 result;
-    A19::decodeInto(sourceBuffer, result);
+    A19::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A19& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A19 decode(std::vector<uint8_t> sourceBuffer) {
+    return A19::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A19 decode(::bebop::Reader& reader) {
+    A19 result;
+    A19::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A19& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A19::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A19& target) {
+    A19::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A19& target) {
@@ -826,6 +1112,7 @@ struct A19 {
 };
 
 struct A20 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i20;
   uint64_t u;
   double f;
@@ -833,7 +1120,7 @@ struct A20 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A20& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A20& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A20::encodeInto(message, writer);
   }
@@ -847,15 +1134,29 @@ struct A20 {
     writer.writeBool(message.b);
   }
 
-  static A20 decode(const uint8_t *sourceBuffer) {
+  static A20 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A20 result;
-    A20::decodeInto(sourceBuffer, result);
+    A20::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A20& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A20 decode(std::vector<uint8_t> sourceBuffer) {
+    return A20::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A20 decode(::bebop::Reader& reader) {
+    A20 result;
+    A20::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A20& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A20::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A20& target) {
+    A20::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A20& target) {
@@ -869,6 +1170,7 @@ struct A20 {
 };
 
 struct A21 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i21;
   uint64_t u;
   double f;
@@ -876,7 +1178,7 @@ struct A21 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A21& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A21& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A21::encodeInto(message, writer);
   }
@@ -890,15 +1192,29 @@ struct A21 {
     writer.writeBool(message.b);
   }
 
-  static A21 decode(const uint8_t *sourceBuffer) {
+  static A21 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A21 result;
-    A21::decodeInto(sourceBuffer, result);
+    A21::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A21& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A21 decode(std::vector<uint8_t> sourceBuffer) {
+    return A21::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A21 decode(::bebop::Reader& reader) {
+    A21 result;
+    A21::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A21& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A21::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A21& target) {
+    A21::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A21& target) {
@@ -912,6 +1228,7 @@ struct A21 {
 };
 
 struct A22 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i22;
   uint64_t u;
   double f;
@@ -919,7 +1236,7 @@ struct A22 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A22& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A22& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A22::encodeInto(message, writer);
   }
@@ -933,15 +1250,29 @@ struct A22 {
     writer.writeBool(message.b);
   }
 
-  static A22 decode(const uint8_t *sourceBuffer) {
+  static A22 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A22 result;
-    A22::decodeInto(sourceBuffer, result);
+    A22::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A22& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A22 decode(std::vector<uint8_t> sourceBuffer) {
+    return A22::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A22 decode(::bebop::Reader& reader) {
+    A22 result;
+    A22::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A22& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A22::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A22& target) {
+    A22::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A22& target) {
@@ -955,6 +1286,7 @@ struct A22 {
 };
 
 struct A23 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i23;
   uint64_t u;
   double f;
@@ -962,7 +1294,7 @@ struct A23 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A23& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A23& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A23::encodeInto(message, writer);
   }
@@ -976,15 +1308,29 @@ struct A23 {
     writer.writeBool(message.b);
   }
 
-  static A23 decode(const uint8_t *sourceBuffer) {
+  static A23 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A23 result;
-    A23::decodeInto(sourceBuffer, result);
+    A23::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A23& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A23 decode(std::vector<uint8_t> sourceBuffer) {
+    return A23::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A23 decode(::bebop::Reader& reader) {
+    A23 result;
+    A23::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A23& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A23::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A23& target) {
+    A23::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A23& target) {
@@ -998,6 +1344,7 @@ struct A23 {
 };
 
 struct A24 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i24;
   uint64_t u;
   double f;
@@ -1005,7 +1352,7 @@ struct A24 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A24& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A24& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A24::encodeInto(message, writer);
   }
@@ -1019,15 +1366,29 @@ struct A24 {
     writer.writeBool(message.b);
   }
 
-  static A24 decode(const uint8_t *sourceBuffer) {
+  static A24 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A24 result;
-    A24::decodeInto(sourceBuffer, result);
+    A24::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A24& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A24 decode(std::vector<uint8_t> sourceBuffer) {
+    return A24::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A24 decode(::bebop::Reader& reader) {
+    A24 result;
+    A24::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A24& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A24::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A24& target) {
+    A24::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A24& target) {
@@ -1041,6 +1402,7 @@ struct A24 {
 };
 
 struct A25 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i25;
   uint64_t u;
   double f;
@@ -1048,7 +1410,7 @@ struct A25 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A25& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A25& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A25::encodeInto(message, writer);
   }
@@ -1062,15 +1424,29 @@ struct A25 {
     writer.writeBool(message.b);
   }
 
-  static A25 decode(const uint8_t *sourceBuffer) {
+  static A25 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A25 result;
-    A25::decodeInto(sourceBuffer, result);
+    A25::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A25& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A25 decode(std::vector<uint8_t> sourceBuffer) {
+    return A25::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A25 decode(::bebop::Reader& reader) {
+    A25 result;
+    A25::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A25& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A25::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A25& target) {
+    A25::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A25& target) {
@@ -1084,6 +1460,7 @@ struct A25 {
 };
 
 struct A26 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i26;
   uint64_t u;
   double f;
@@ -1091,7 +1468,7 @@ struct A26 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A26& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A26& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A26::encodeInto(message, writer);
   }
@@ -1105,15 +1482,29 @@ struct A26 {
     writer.writeBool(message.b);
   }
 
-  static A26 decode(const uint8_t *sourceBuffer) {
+  static A26 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A26 result;
-    A26::decodeInto(sourceBuffer, result);
+    A26::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A26& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A26 decode(std::vector<uint8_t> sourceBuffer) {
+    return A26::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A26 decode(::bebop::Reader& reader) {
+    A26 result;
+    A26::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A26& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A26::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A26& target) {
+    A26::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A26& target) {
@@ -1127,6 +1518,7 @@ struct A26 {
 };
 
 struct A27 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i27;
   uint64_t u;
   double f;
@@ -1134,7 +1526,7 @@ struct A27 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A27& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A27& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A27::encodeInto(message, writer);
   }
@@ -1148,15 +1540,29 @@ struct A27 {
     writer.writeBool(message.b);
   }
 
-  static A27 decode(const uint8_t *sourceBuffer) {
+  static A27 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A27 result;
-    A27::decodeInto(sourceBuffer, result);
+    A27::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A27& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A27 decode(std::vector<uint8_t> sourceBuffer) {
+    return A27::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A27 decode(::bebop::Reader& reader) {
+    A27 result;
+    A27::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A27& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A27::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A27& target) {
+    A27::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A27& target) {
@@ -1170,6 +1576,7 @@ struct A27 {
 };
 
 struct A28 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i28;
   uint64_t u;
   double f;
@@ -1177,7 +1584,7 @@ struct A28 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A28& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A28& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A28::encodeInto(message, writer);
   }
@@ -1191,15 +1598,29 @@ struct A28 {
     writer.writeBool(message.b);
   }
 
-  static A28 decode(const uint8_t *sourceBuffer) {
+  static A28 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A28 result;
-    A28::decodeInto(sourceBuffer, result);
+    A28::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A28& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A28 decode(std::vector<uint8_t> sourceBuffer) {
+    return A28::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A28 decode(::bebop::Reader& reader) {
+    A28 result;
+    A28::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A28& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A28::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A28& target) {
+    A28::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A28& target) {
@@ -1213,6 +1634,7 @@ struct A28 {
 };
 
 struct A29 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i29;
   uint64_t u;
   double f;
@@ -1220,7 +1642,7 @@ struct A29 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A29& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A29& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A29::encodeInto(message, writer);
   }
@@ -1234,15 +1656,29 @@ struct A29 {
     writer.writeBool(message.b);
   }
 
-  static A29 decode(const uint8_t *sourceBuffer) {
+  static A29 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A29 result;
-    A29::decodeInto(sourceBuffer, result);
+    A29::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A29& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A29 decode(std::vector<uint8_t> sourceBuffer) {
+    return A29::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A29 decode(::bebop::Reader& reader) {
+    A29 result;
+    A29::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A29& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A29::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A29& target) {
+    A29::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A29& target) {
@@ -1256,6 +1692,7 @@ struct A29 {
 };
 
 struct A30 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i30;
   uint64_t u;
   double f;
@@ -1263,7 +1700,7 @@ struct A30 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A30& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A30& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A30::encodeInto(message, writer);
   }
@@ -1277,15 +1714,29 @@ struct A30 {
     writer.writeBool(message.b);
   }
 
-  static A30 decode(const uint8_t *sourceBuffer) {
+  static A30 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A30 result;
-    A30::decodeInto(sourceBuffer, result);
+    A30::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A30& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A30 decode(std::vector<uint8_t> sourceBuffer) {
+    return A30::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A30 decode(::bebop::Reader& reader) {
+    A30 result;
+    A30::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A30& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A30::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A30& target) {
+    A30::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A30& target) {
@@ -1299,6 +1750,7 @@ struct A30 {
 };
 
 struct A31 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i31;
   uint64_t u;
   double f;
@@ -1306,7 +1758,7 @@ struct A31 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A31& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A31& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A31::encodeInto(message, writer);
   }
@@ -1320,15 +1772,29 @@ struct A31 {
     writer.writeBool(message.b);
   }
 
-  static A31 decode(const uint8_t *sourceBuffer) {
+  static A31 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A31 result;
-    A31::decodeInto(sourceBuffer, result);
+    A31::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A31& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A31 decode(std::vector<uint8_t> sourceBuffer) {
+    return A31::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A31 decode(::bebop::Reader& reader) {
+    A31 result;
+    A31::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A31& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A31::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A31& target) {
+    A31::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A31& target) {
@@ -1342,6 +1808,7 @@ struct A31 {
 };
 
 struct A32 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i32;
   uint64_t u;
   double f;
@@ -1349,7 +1816,7 @@ struct A32 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A32& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A32& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A32::encodeInto(message, writer);
   }
@@ -1363,15 +1830,29 @@ struct A32 {
     writer.writeBool(message.b);
   }
 
-  static A32 decode(const uint8_t *sourceBuffer) {
+  static A32 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A32 result;
-    A32::decodeInto(sourceBuffer, result);
+    A32::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A32& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A32 decode(std::vector<uint8_t> sourceBuffer) {
+    return A32::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A32 decode(::bebop::Reader& reader) {
+    A32 result;
+    A32::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A32& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A32::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A32& target) {
+    A32::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A32& target) {
@@ -1385,6 +1866,7 @@ struct A32 {
 };
 
 struct A33 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i33;
   uint64_t u;
   double f;
@@ -1392,7 +1874,7 @@ struct A33 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A33& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A33& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A33::encodeInto(message, writer);
   }
@@ -1406,15 +1888,29 @@ struct A33 {
     writer.writeBool(message.b);
   }
 
-  static A33 decode(const uint8_t *sourceBuffer) {
+  static A33 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A33 result;
-    A33::decodeInto(sourceBuffer, result);
+    A33::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A33& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A33 decode(std::vector<uint8_t> sourceBuffer) {
+    return A33::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A33 decode(::bebop::Reader& reader) {
+    A33 result;
+    A33::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A33& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A33::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A33& target) {
+    A33::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A33& target) {
@@ -1428,6 +1924,7 @@ struct A33 {
 };
 
 struct A34 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i34;
   uint64_t u;
   double f;
@@ -1435,7 +1932,7 @@ struct A34 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A34& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A34& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A34::encodeInto(message, writer);
   }
@@ -1449,15 +1946,29 @@ struct A34 {
     writer.writeBool(message.b);
   }
 
-  static A34 decode(const uint8_t *sourceBuffer) {
+  static A34 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A34 result;
-    A34::decodeInto(sourceBuffer, result);
+    A34::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A34& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A34 decode(std::vector<uint8_t> sourceBuffer) {
+    return A34::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A34 decode(::bebop::Reader& reader) {
+    A34 result;
+    A34::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A34& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A34::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A34& target) {
+    A34::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A34& target) {
@@ -1471,6 +1982,7 @@ struct A34 {
 };
 
 struct A35 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i35;
   uint64_t u;
   double f;
@@ -1478,7 +1990,7 @@ struct A35 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A35& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A35& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A35::encodeInto(message, writer);
   }
@@ -1492,15 +2004,29 @@ struct A35 {
     writer.writeBool(message.b);
   }
 
-  static A35 decode(const uint8_t *sourceBuffer) {
+  static A35 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A35 result;
-    A35::decodeInto(sourceBuffer, result);
+    A35::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A35& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A35 decode(std::vector<uint8_t> sourceBuffer) {
+    return A35::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A35 decode(::bebop::Reader& reader) {
+    A35 result;
+    A35::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A35& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A35::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A35& target) {
+    A35::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A35& target) {
@@ -1514,6 +2040,7 @@ struct A35 {
 };
 
 struct A36 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i36;
   uint64_t u;
   double f;
@@ -1521,7 +2048,7 @@ struct A36 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A36& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A36& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A36::encodeInto(message, writer);
   }
@@ -1535,15 +2062,29 @@ struct A36 {
     writer.writeBool(message.b);
   }
 
-  static A36 decode(const uint8_t *sourceBuffer) {
+  static A36 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A36 result;
-    A36::decodeInto(sourceBuffer, result);
+    A36::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A36& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A36 decode(std::vector<uint8_t> sourceBuffer) {
+    return A36::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A36 decode(::bebop::Reader& reader) {
+    A36 result;
+    A36::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A36& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A36::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A36& target) {
+    A36::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A36& target) {
@@ -1557,6 +2098,7 @@ struct A36 {
 };
 
 struct A37 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i37;
   uint64_t u;
   double f;
@@ -1564,7 +2106,7 @@ struct A37 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A37& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A37& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A37::encodeInto(message, writer);
   }
@@ -1578,15 +2120,29 @@ struct A37 {
     writer.writeBool(message.b);
   }
 
-  static A37 decode(const uint8_t *sourceBuffer) {
+  static A37 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A37 result;
-    A37::decodeInto(sourceBuffer, result);
+    A37::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A37& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A37 decode(std::vector<uint8_t> sourceBuffer) {
+    return A37::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A37 decode(::bebop::Reader& reader) {
+    A37 result;
+    A37::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A37& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A37::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A37& target) {
+    A37::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A37& target) {
@@ -1600,6 +2156,7 @@ struct A37 {
 };
 
 struct A38 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i38;
   uint64_t u;
   double f;
@@ -1607,7 +2164,7 @@ struct A38 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A38& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A38& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A38::encodeInto(message, writer);
   }
@@ -1621,15 +2178,29 @@ struct A38 {
     writer.writeBool(message.b);
   }
 
-  static A38 decode(const uint8_t *sourceBuffer) {
+  static A38 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A38 result;
-    A38::decodeInto(sourceBuffer, result);
+    A38::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A38& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A38 decode(std::vector<uint8_t> sourceBuffer) {
+    return A38::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A38 decode(::bebop::Reader& reader) {
+    A38 result;
+    A38::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A38& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A38::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A38& target) {
+    A38::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A38& target) {
@@ -1643,6 +2214,7 @@ struct A38 {
 };
 
 struct A39 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i39;
   uint64_t u;
   double f;
@@ -1650,7 +2222,7 @@ struct A39 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A39& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A39& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A39::encodeInto(message, writer);
   }
@@ -1664,15 +2236,29 @@ struct A39 {
     writer.writeBool(message.b);
   }
 
-  static A39 decode(const uint8_t *sourceBuffer) {
+  static A39 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A39 result;
-    A39::decodeInto(sourceBuffer, result);
+    A39::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A39& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A39 decode(std::vector<uint8_t> sourceBuffer) {
+    return A39::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A39 decode(::bebop::Reader& reader) {
+    A39 result;
+    A39::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A39& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A39::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A39& target) {
+    A39::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A39& target) {
@@ -1686,6 +2272,7 @@ struct A39 {
 };
 
 struct A40 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i40;
   uint64_t u;
   double f;
@@ -1693,7 +2280,7 @@ struct A40 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A40& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A40& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A40::encodeInto(message, writer);
   }
@@ -1707,15 +2294,29 @@ struct A40 {
     writer.writeBool(message.b);
   }
 
-  static A40 decode(const uint8_t *sourceBuffer) {
+  static A40 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A40 result;
-    A40::decodeInto(sourceBuffer, result);
+    A40::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A40& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A40 decode(std::vector<uint8_t> sourceBuffer) {
+    return A40::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A40 decode(::bebop::Reader& reader) {
+    A40 result;
+    A40::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A40& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A40::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A40& target) {
+    A40::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A40& target) {
@@ -1729,6 +2330,7 @@ struct A40 {
 };
 
 struct A41 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i41;
   uint64_t u;
   double f;
@@ -1736,7 +2338,7 @@ struct A41 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A41& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A41& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A41::encodeInto(message, writer);
   }
@@ -1750,15 +2352,29 @@ struct A41 {
     writer.writeBool(message.b);
   }
 
-  static A41 decode(const uint8_t *sourceBuffer) {
+  static A41 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A41 result;
-    A41::decodeInto(sourceBuffer, result);
+    A41::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A41& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A41 decode(std::vector<uint8_t> sourceBuffer) {
+    return A41::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A41 decode(::bebop::Reader& reader) {
+    A41 result;
+    A41::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A41& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A41::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A41& target) {
+    A41::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A41& target) {
@@ -1772,6 +2388,7 @@ struct A41 {
 };
 
 struct A42 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i42;
   uint64_t u;
   double f;
@@ -1779,7 +2396,7 @@ struct A42 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A42& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A42& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A42::encodeInto(message, writer);
   }
@@ -1793,15 +2410,29 @@ struct A42 {
     writer.writeBool(message.b);
   }
 
-  static A42 decode(const uint8_t *sourceBuffer) {
+  static A42 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A42 result;
-    A42::decodeInto(sourceBuffer, result);
+    A42::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A42& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A42 decode(std::vector<uint8_t> sourceBuffer) {
+    return A42::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A42 decode(::bebop::Reader& reader) {
+    A42 result;
+    A42::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A42& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A42::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A42& target) {
+    A42::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A42& target) {
@@ -1815,6 +2446,7 @@ struct A42 {
 };
 
 struct A43 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i43;
   uint64_t u;
   double f;
@@ -1822,7 +2454,7 @@ struct A43 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A43& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A43& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A43::encodeInto(message, writer);
   }
@@ -1836,15 +2468,29 @@ struct A43 {
     writer.writeBool(message.b);
   }
 
-  static A43 decode(const uint8_t *sourceBuffer) {
+  static A43 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A43 result;
-    A43::decodeInto(sourceBuffer, result);
+    A43::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A43& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A43 decode(std::vector<uint8_t> sourceBuffer) {
+    return A43::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A43 decode(::bebop::Reader& reader) {
+    A43 result;
+    A43::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A43& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A43::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A43& target) {
+    A43::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A43& target) {
@@ -1858,6 +2504,7 @@ struct A43 {
 };
 
 struct A44 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i44;
   uint64_t u;
   double f;
@@ -1865,7 +2512,7 @@ struct A44 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A44& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A44& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A44::encodeInto(message, writer);
   }
@@ -1879,15 +2526,29 @@ struct A44 {
     writer.writeBool(message.b);
   }
 
-  static A44 decode(const uint8_t *sourceBuffer) {
+  static A44 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A44 result;
-    A44::decodeInto(sourceBuffer, result);
+    A44::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A44& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A44 decode(std::vector<uint8_t> sourceBuffer) {
+    return A44::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A44 decode(::bebop::Reader& reader) {
+    A44 result;
+    A44::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A44& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A44::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A44& target) {
+    A44::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A44& target) {
@@ -1901,6 +2562,7 @@ struct A44 {
 };
 
 struct A45 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i45;
   uint64_t u;
   double f;
@@ -1908,7 +2570,7 @@ struct A45 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A45& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A45& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A45::encodeInto(message, writer);
   }
@@ -1922,15 +2584,29 @@ struct A45 {
     writer.writeBool(message.b);
   }
 
-  static A45 decode(const uint8_t *sourceBuffer) {
+  static A45 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A45 result;
-    A45::decodeInto(sourceBuffer, result);
+    A45::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A45& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A45 decode(std::vector<uint8_t> sourceBuffer) {
+    return A45::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A45 decode(::bebop::Reader& reader) {
+    A45 result;
+    A45::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A45& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A45::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A45& target) {
+    A45::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A45& target) {
@@ -1944,6 +2620,7 @@ struct A45 {
 };
 
 struct A46 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i46;
   uint64_t u;
   double f;
@@ -1951,7 +2628,7 @@ struct A46 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A46& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A46& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A46::encodeInto(message, writer);
   }
@@ -1965,15 +2642,29 @@ struct A46 {
     writer.writeBool(message.b);
   }
 
-  static A46 decode(const uint8_t *sourceBuffer) {
+  static A46 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A46 result;
-    A46::decodeInto(sourceBuffer, result);
+    A46::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A46& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A46 decode(std::vector<uint8_t> sourceBuffer) {
+    return A46::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A46 decode(::bebop::Reader& reader) {
+    A46 result;
+    A46::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A46& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A46::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A46& target) {
+    A46::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A46& target) {
@@ -1987,6 +2678,7 @@ struct A46 {
 };
 
 struct A47 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i47;
   uint64_t u;
   double f;
@@ -1994,7 +2686,7 @@ struct A47 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A47& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A47& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A47::encodeInto(message, writer);
   }
@@ -2008,15 +2700,29 @@ struct A47 {
     writer.writeBool(message.b);
   }
 
-  static A47 decode(const uint8_t *sourceBuffer) {
+  static A47 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A47 result;
-    A47::decodeInto(sourceBuffer, result);
+    A47::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A47& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A47 decode(std::vector<uint8_t> sourceBuffer) {
+    return A47::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A47 decode(::bebop::Reader& reader) {
+    A47 result;
+    A47::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A47& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A47::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A47& target) {
+    A47::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A47& target) {
@@ -2030,6 +2736,7 @@ struct A47 {
 };
 
 struct A48 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i48;
   uint64_t u;
   double f;
@@ -2037,7 +2744,7 @@ struct A48 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A48& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A48& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A48::encodeInto(message, writer);
   }
@@ -2051,15 +2758,29 @@ struct A48 {
     writer.writeBool(message.b);
   }
 
-  static A48 decode(const uint8_t *sourceBuffer) {
+  static A48 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A48 result;
-    A48::decodeInto(sourceBuffer, result);
+    A48::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A48& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A48 decode(std::vector<uint8_t> sourceBuffer) {
+    return A48::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A48 decode(::bebop::Reader& reader) {
+    A48 result;
+    A48::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A48& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A48::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A48& target) {
+    A48::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A48& target) {
@@ -2073,6 +2794,7 @@ struct A48 {
 };
 
 struct A49 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i49;
   uint64_t u;
   double f;
@@ -2080,7 +2802,7 @@ struct A49 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A49& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A49& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A49::encodeInto(message, writer);
   }
@@ -2094,15 +2816,29 @@ struct A49 {
     writer.writeBool(message.b);
   }
 
-  static A49 decode(const uint8_t *sourceBuffer) {
+  static A49 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A49 result;
-    A49::decodeInto(sourceBuffer, result);
+    A49::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A49& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A49 decode(std::vector<uint8_t> sourceBuffer) {
+    return A49::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A49 decode(::bebop::Reader& reader) {
+    A49 result;
+    A49::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A49& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A49::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A49& target) {
+    A49::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A49& target) {
@@ -2116,6 +2852,7 @@ struct A49 {
 };
 
 struct A50 {
+  static const size_t minimalEncodedSize = 41;
   int32_t i50;
   uint64_t u;
   double f;
@@ -2123,7 +2860,7 @@ struct A50 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const A50& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A50& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A50::encodeInto(message, writer);
   }
@@ -2137,15 +2874,29 @@ struct A50 {
     writer.writeBool(message.b);
   }
 
-  static A50 decode(const uint8_t *sourceBuffer) {
+  static A50 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A50 result;
-    A50::decodeInto(sourceBuffer, result);
+    A50::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A50& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A50 decode(std::vector<uint8_t> sourceBuffer) {
+    return A50::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A50 decode(::bebop::Reader& reader) {
+    A50 result;
+    A50::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A50& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A50::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A50& target) {
+    A50::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A50& target) {
@@ -2160,17 +2911,18 @@ struct A50 {
 
 /// Option A: put the whole thing in a union.
 struct U {
+  static const size_t minimalEncodedSize = 46;
   std::variant<A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, A22, A23, A24, A25, A26, A27, A28, A29, A30, A31, A32, A33, A34, A35, A36, A37, A38, A39, A40, A41, A42, A43, A44, A45, A46, A47, A48, A49, A50> variant;
-  static void encodeInto(const U& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const U& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     U::encodeInto(message, writer);
   }
 
   static void encodeInto(const U& message, ::bebop::Writer& writer) {
     const auto pos = writer.reserveMessageLength();
-    const auto start = writer.length();
     const uint8_t discriminator = message.variant.index() + 1;
     writer.writeByte(discriminator);
+    const auto start = writer.length();
     switch (discriminator) {
      case 1:
       A1::encodeInto(std::get<0>(message.variant), writer);
@@ -2327,20 +3079,34 @@ struct U {
     writer.fillMessageLength(pos, end - start);
   }
 
-  static U decode(const uint8_t *sourceBuffer) {
+  static U decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     U result;
-    U::decodeInto(sourceBuffer, result);
+    U::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, U& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static U decode(std::vector<uint8_t> sourceBuffer) {
+    return U::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static U decode(::bebop::Reader& reader) {
+    U result;
+    U::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, U& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     U::decodeInto(reader, target);
   }
 
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, U& target) {
+    U::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
+  }
+
   static void decodeInto(::bebop::Reader& reader, U& target) {
-    const auto length = reader.readMessageLength();
-    const auto end = reader.pointer() + length;
+    const auto length = reader.readLengthPrefix();
+    const auto end = reader.pointer() + length + 1;
     switch (reader.readByte()) {
       case 1:
         target.variant.emplace<0>();
@@ -2550,11 +3316,12 @@ struct U {
 };
 
 struct A {
+  static const size_t minimalEncodedSize = 54;
   uint32_t containerOpcode;
   uint32_t protocolVersion;
   U u;
 
-  static void encodeInto(const A& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const A& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     A::encodeInto(message, writer);
   }
@@ -2565,15 +3332,29 @@ struct A {
     U::encodeInto(message.u, writer);
   }
 
-  static A decode(const uint8_t *sourceBuffer) {
+  static A decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     A result;
-    A::decodeInto(sourceBuffer, result);
+    A::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, A& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static A decode(std::vector<uint8_t> sourceBuffer) {
+    return A::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static A decode(::bebop::Reader& reader) {
+    A result;
+    A::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, A& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     A::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, A& target) {
+    A::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, A& target) {

--- a/Laboratory/C++/gen/union_perf_b.hpp
+++ b/Laboratory/C++/gen/union_perf_b.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -10,11 +11,12 @@
 
 /// Option B: an "encodedData" field, that "decode" is called a second time on.
 struct B {
+  static const size_t minimalEncodedSize = 12;
   uint32_t protocolVersion;
   uint32_t incomingOpcode;
   std::vector<uint8_t> encodedData;
 
-  static void encodeInto(const B& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B::encodeInto(message, writer);
   }
@@ -25,15 +27,29 @@ struct B {
     writer.writeBytes(message.encodedData);
   }
 
-  static B decode(const uint8_t *sourceBuffer) {
+  static B decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B result;
-    B::decodeInto(sourceBuffer, result);
+    B::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B decode(std::vector<uint8_t> sourceBuffer) {
+    return B::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B decode(::bebop::Reader& reader) {
+    B result;
+    B::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B& target) {
+    B::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B& target) {
@@ -44,6 +60,7 @@ struct B {
 };
 
 struct B1 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x1;
 
   int32_t i1;
@@ -53,7 +70,7 @@ struct B1 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B1& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B1& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B1::encodeInto(message, writer);
   }
@@ -67,15 +84,29 @@ struct B1 {
     writer.writeBool(message.b);
   }
 
-  static B1 decode(const uint8_t *sourceBuffer) {
+  static B1 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B1 result;
-    B1::decodeInto(sourceBuffer, result);
+    B1::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B1& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B1 decode(std::vector<uint8_t> sourceBuffer) {
+    return B1::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B1 decode(::bebop::Reader& reader) {
+    B1 result;
+    B1::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B1& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B1::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B1& target) {
+    B1::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B1& target) {
@@ -89,6 +120,7 @@ struct B1 {
 };
 
 struct B2 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x2;
 
   int32_t i2;
@@ -98,7 +130,7 @@ struct B2 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B2& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B2& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B2::encodeInto(message, writer);
   }
@@ -112,15 +144,29 @@ struct B2 {
     writer.writeBool(message.b);
   }
 
-  static B2 decode(const uint8_t *sourceBuffer) {
+  static B2 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B2 result;
-    B2::decodeInto(sourceBuffer, result);
+    B2::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B2& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B2 decode(std::vector<uint8_t> sourceBuffer) {
+    return B2::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B2 decode(::bebop::Reader& reader) {
+    B2 result;
+    B2::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B2& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B2::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B2& target) {
+    B2::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B2& target) {
@@ -134,6 +180,7 @@ struct B2 {
 };
 
 struct B3 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x3;
 
   int32_t i3;
@@ -143,7 +190,7 @@ struct B3 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B3& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B3& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B3::encodeInto(message, writer);
   }
@@ -157,15 +204,29 @@ struct B3 {
     writer.writeBool(message.b);
   }
 
-  static B3 decode(const uint8_t *sourceBuffer) {
+  static B3 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B3 result;
-    B3::decodeInto(sourceBuffer, result);
+    B3::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B3& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B3 decode(std::vector<uint8_t> sourceBuffer) {
+    return B3::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B3 decode(::bebop::Reader& reader) {
+    B3 result;
+    B3::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B3& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B3::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B3& target) {
+    B3::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B3& target) {
@@ -179,6 +240,7 @@ struct B3 {
 };
 
 struct B4 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x4;
 
   int32_t i4;
@@ -188,7 +250,7 @@ struct B4 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B4& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B4& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B4::encodeInto(message, writer);
   }
@@ -202,15 +264,29 @@ struct B4 {
     writer.writeBool(message.b);
   }
 
-  static B4 decode(const uint8_t *sourceBuffer) {
+  static B4 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B4 result;
-    B4::decodeInto(sourceBuffer, result);
+    B4::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B4& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B4 decode(std::vector<uint8_t> sourceBuffer) {
+    return B4::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B4 decode(::bebop::Reader& reader) {
+    B4 result;
+    B4::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B4& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B4::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B4& target) {
+    B4::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B4& target) {
@@ -224,6 +300,7 @@ struct B4 {
 };
 
 struct B5 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x5;
 
   int32_t i5;
@@ -233,7 +310,7 @@ struct B5 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B5& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B5& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B5::encodeInto(message, writer);
   }
@@ -247,15 +324,29 @@ struct B5 {
     writer.writeBool(message.b);
   }
 
-  static B5 decode(const uint8_t *sourceBuffer) {
+  static B5 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B5 result;
-    B5::decodeInto(sourceBuffer, result);
+    B5::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B5& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B5 decode(std::vector<uint8_t> sourceBuffer) {
+    return B5::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B5 decode(::bebop::Reader& reader) {
+    B5 result;
+    B5::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B5& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B5::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B5& target) {
+    B5::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B5& target) {
@@ -269,6 +360,7 @@ struct B5 {
 };
 
 struct B6 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x6;
 
   int32_t i6;
@@ -278,7 +370,7 @@ struct B6 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B6& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B6& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B6::encodeInto(message, writer);
   }
@@ -292,15 +384,29 @@ struct B6 {
     writer.writeBool(message.b);
   }
 
-  static B6 decode(const uint8_t *sourceBuffer) {
+  static B6 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B6 result;
-    B6::decodeInto(sourceBuffer, result);
+    B6::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B6& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B6 decode(std::vector<uint8_t> sourceBuffer) {
+    return B6::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B6 decode(::bebop::Reader& reader) {
+    B6 result;
+    B6::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B6& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B6::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B6& target) {
+    B6::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B6& target) {
@@ -314,6 +420,7 @@ struct B6 {
 };
 
 struct B7 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x7;
 
   int32_t i7;
@@ -323,7 +430,7 @@ struct B7 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B7& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B7& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B7::encodeInto(message, writer);
   }
@@ -337,15 +444,29 @@ struct B7 {
     writer.writeBool(message.b);
   }
 
-  static B7 decode(const uint8_t *sourceBuffer) {
+  static B7 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B7 result;
-    B7::decodeInto(sourceBuffer, result);
+    B7::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B7& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B7 decode(std::vector<uint8_t> sourceBuffer) {
+    return B7::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B7 decode(::bebop::Reader& reader) {
+    B7 result;
+    B7::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B7& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B7::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B7& target) {
+    B7::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B7& target) {
@@ -359,6 +480,7 @@ struct B7 {
 };
 
 struct B8 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x8;
 
   int32_t i8;
@@ -368,7 +490,7 @@ struct B8 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B8& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B8& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B8::encodeInto(message, writer);
   }
@@ -382,15 +504,29 @@ struct B8 {
     writer.writeBool(message.b);
   }
 
-  static B8 decode(const uint8_t *sourceBuffer) {
+  static B8 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B8 result;
-    B8::decodeInto(sourceBuffer, result);
+    B8::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B8& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B8 decode(std::vector<uint8_t> sourceBuffer) {
+    return B8::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B8 decode(::bebop::Reader& reader) {
+    B8 result;
+    B8::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B8& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B8::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B8& target) {
+    B8::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B8& target) {
@@ -404,6 +540,7 @@ struct B8 {
 };
 
 struct B9 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x9;
 
   int32_t i9;
@@ -413,7 +550,7 @@ struct B9 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B9& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B9& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B9::encodeInto(message, writer);
   }
@@ -427,15 +564,29 @@ struct B9 {
     writer.writeBool(message.b);
   }
 
-  static B9 decode(const uint8_t *sourceBuffer) {
+  static B9 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B9 result;
-    B9::decodeInto(sourceBuffer, result);
+    B9::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B9& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B9 decode(std::vector<uint8_t> sourceBuffer) {
+    return B9::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B9 decode(::bebop::Reader& reader) {
+    B9 result;
+    B9::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B9& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B9::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B9& target) {
+    B9::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B9& target) {
@@ -449,6 +600,7 @@ struct B9 {
 };
 
 struct B10 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0xA;
 
   int32_t i10;
@@ -458,7 +610,7 @@ struct B10 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B10& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B10& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B10::encodeInto(message, writer);
   }
@@ -472,15 +624,29 @@ struct B10 {
     writer.writeBool(message.b);
   }
 
-  static B10 decode(const uint8_t *sourceBuffer) {
+  static B10 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B10 result;
-    B10::decodeInto(sourceBuffer, result);
+    B10::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B10& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B10 decode(std::vector<uint8_t> sourceBuffer) {
+    return B10::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B10 decode(::bebop::Reader& reader) {
+    B10 result;
+    B10::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B10& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B10::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B10& target) {
+    B10::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B10& target) {
@@ -494,6 +660,7 @@ struct B10 {
 };
 
 struct B11 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0xB;
 
   int32_t i11;
@@ -503,7 +670,7 @@ struct B11 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B11& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B11& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B11::encodeInto(message, writer);
   }
@@ -517,15 +684,29 @@ struct B11 {
     writer.writeBool(message.b);
   }
 
-  static B11 decode(const uint8_t *sourceBuffer) {
+  static B11 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B11 result;
-    B11::decodeInto(sourceBuffer, result);
+    B11::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B11& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B11 decode(std::vector<uint8_t> sourceBuffer) {
+    return B11::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B11 decode(::bebop::Reader& reader) {
+    B11 result;
+    B11::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B11& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B11::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B11& target) {
+    B11::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B11& target) {
@@ -539,6 +720,7 @@ struct B11 {
 };
 
 struct B12 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0xC;
 
   int32_t i12;
@@ -548,7 +730,7 @@ struct B12 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B12& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B12& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B12::encodeInto(message, writer);
   }
@@ -562,15 +744,29 @@ struct B12 {
     writer.writeBool(message.b);
   }
 
-  static B12 decode(const uint8_t *sourceBuffer) {
+  static B12 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B12 result;
-    B12::decodeInto(sourceBuffer, result);
+    B12::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B12& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B12 decode(std::vector<uint8_t> sourceBuffer) {
+    return B12::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B12 decode(::bebop::Reader& reader) {
+    B12 result;
+    B12::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B12& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B12::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B12& target) {
+    B12::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B12& target) {
@@ -584,6 +780,7 @@ struct B12 {
 };
 
 struct B13 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0xD;
 
   int32_t i13;
@@ -593,7 +790,7 @@ struct B13 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B13& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B13& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B13::encodeInto(message, writer);
   }
@@ -607,15 +804,29 @@ struct B13 {
     writer.writeBool(message.b);
   }
 
-  static B13 decode(const uint8_t *sourceBuffer) {
+  static B13 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B13 result;
-    B13::decodeInto(sourceBuffer, result);
+    B13::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B13& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B13 decode(std::vector<uint8_t> sourceBuffer) {
+    return B13::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B13 decode(::bebop::Reader& reader) {
+    B13 result;
+    B13::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B13& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B13::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B13& target) {
+    B13::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B13& target) {
@@ -629,6 +840,7 @@ struct B13 {
 };
 
 struct B14 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0xE;
 
   int32_t i14;
@@ -638,7 +850,7 @@ struct B14 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B14& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B14& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B14::encodeInto(message, writer);
   }
@@ -652,15 +864,29 @@ struct B14 {
     writer.writeBool(message.b);
   }
 
-  static B14 decode(const uint8_t *sourceBuffer) {
+  static B14 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B14 result;
-    B14::decodeInto(sourceBuffer, result);
+    B14::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B14& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B14 decode(std::vector<uint8_t> sourceBuffer) {
+    return B14::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B14 decode(::bebop::Reader& reader) {
+    B14 result;
+    B14::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B14& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B14::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B14& target) {
+    B14::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B14& target) {
@@ -674,6 +900,7 @@ struct B14 {
 };
 
 struct B15 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0xF;
 
   int32_t i15;
@@ -683,7 +910,7 @@ struct B15 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B15& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B15& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B15::encodeInto(message, writer);
   }
@@ -697,15 +924,29 @@ struct B15 {
     writer.writeBool(message.b);
   }
 
-  static B15 decode(const uint8_t *sourceBuffer) {
+  static B15 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B15 result;
-    B15::decodeInto(sourceBuffer, result);
+    B15::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B15& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B15 decode(std::vector<uint8_t> sourceBuffer) {
+    return B15::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B15 decode(::bebop::Reader& reader) {
+    B15 result;
+    B15::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B15& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B15::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B15& target) {
+    B15::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B15& target) {
@@ -719,6 +960,7 @@ struct B15 {
 };
 
 struct B16 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x10;
 
   int32_t i16;
@@ -728,7 +970,7 @@ struct B16 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B16& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B16& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B16::encodeInto(message, writer);
   }
@@ -742,15 +984,29 @@ struct B16 {
     writer.writeBool(message.b);
   }
 
-  static B16 decode(const uint8_t *sourceBuffer) {
+  static B16 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B16 result;
-    B16::decodeInto(sourceBuffer, result);
+    B16::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B16& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B16 decode(std::vector<uint8_t> sourceBuffer) {
+    return B16::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B16 decode(::bebop::Reader& reader) {
+    B16 result;
+    B16::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B16& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B16::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B16& target) {
+    B16::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B16& target) {
@@ -764,6 +1020,7 @@ struct B16 {
 };
 
 struct B17 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x11;
 
   int32_t i17;
@@ -773,7 +1030,7 @@ struct B17 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B17& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B17& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B17::encodeInto(message, writer);
   }
@@ -787,15 +1044,29 @@ struct B17 {
     writer.writeBool(message.b);
   }
 
-  static B17 decode(const uint8_t *sourceBuffer) {
+  static B17 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B17 result;
-    B17::decodeInto(sourceBuffer, result);
+    B17::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B17& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B17 decode(std::vector<uint8_t> sourceBuffer) {
+    return B17::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B17 decode(::bebop::Reader& reader) {
+    B17 result;
+    B17::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B17& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B17::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B17& target) {
+    B17::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B17& target) {
@@ -809,6 +1080,7 @@ struct B17 {
 };
 
 struct B18 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x12;
 
   int32_t i18;
@@ -818,7 +1090,7 @@ struct B18 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B18& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B18& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B18::encodeInto(message, writer);
   }
@@ -832,15 +1104,29 @@ struct B18 {
     writer.writeBool(message.b);
   }
 
-  static B18 decode(const uint8_t *sourceBuffer) {
+  static B18 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B18 result;
-    B18::decodeInto(sourceBuffer, result);
+    B18::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B18& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B18 decode(std::vector<uint8_t> sourceBuffer) {
+    return B18::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B18 decode(::bebop::Reader& reader) {
+    B18 result;
+    B18::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B18& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B18::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B18& target) {
+    B18::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B18& target) {
@@ -854,6 +1140,7 @@ struct B18 {
 };
 
 struct B19 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x13;
 
   int32_t i19;
@@ -863,7 +1150,7 @@ struct B19 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B19& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B19& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B19::encodeInto(message, writer);
   }
@@ -877,15 +1164,29 @@ struct B19 {
     writer.writeBool(message.b);
   }
 
-  static B19 decode(const uint8_t *sourceBuffer) {
+  static B19 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B19 result;
-    B19::decodeInto(sourceBuffer, result);
+    B19::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B19& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B19 decode(std::vector<uint8_t> sourceBuffer) {
+    return B19::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B19 decode(::bebop::Reader& reader) {
+    B19 result;
+    B19::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B19& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B19::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B19& target) {
+    B19::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B19& target) {
@@ -899,6 +1200,7 @@ struct B19 {
 };
 
 struct B20 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x14;
 
   int32_t i20;
@@ -908,7 +1210,7 @@ struct B20 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B20& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B20& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B20::encodeInto(message, writer);
   }
@@ -922,15 +1224,29 @@ struct B20 {
     writer.writeBool(message.b);
   }
 
-  static B20 decode(const uint8_t *sourceBuffer) {
+  static B20 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B20 result;
-    B20::decodeInto(sourceBuffer, result);
+    B20::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B20& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B20 decode(std::vector<uint8_t> sourceBuffer) {
+    return B20::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B20 decode(::bebop::Reader& reader) {
+    B20 result;
+    B20::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B20& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B20::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B20& target) {
+    B20::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B20& target) {
@@ -944,6 +1260,7 @@ struct B20 {
 };
 
 struct B21 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x15;
 
   int32_t i21;
@@ -953,7 +1270,7 @@ struct B21 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B21& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B21& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B21::encodeInto(message, writer);
   }
@@ -967,15 +1284,29 @@ struct B21 {
     writer.writeBool(message.b);
   }
 
-  static B21 decode(const uint8_t *sourceBuffer) {
+  static B21 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B21 result;
-    B21::decodeInto(sourceBuffer, result);
+    B21::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B21& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B21 decode(std::vector<uint8_t> sourceBuffer) {
+    return B21::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B21 decode(::bebop::Reader& reader) {
+    B21 result;
+    B21::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B21& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B21::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B21& target) {
+    B21::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B21& target) {
@@ -989,6 +1320,7 @@ struct B21 {
 };
 
 struct B22 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x16;
 
   int32_t i22;
@@ -998,7 +1330,7 @@ struct B22 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B22& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B22& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B22::encodeInto(message, writer);
   }
@@ -1012,15 +1344,29 @@ struct B22 {
     writer.writeBool(message.b);
   }
 
-  static B22 decode(const uint8_t *sourceBuffer) {
+  static B22 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B22 result;
-    B22::decodeInto(sourceBuffer, result);
+    B22::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B22& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B22 decode(std::vector<uint8_t> sourceBuffer) {
+    return B22::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B22 decode(::bebop::Reader& reader) {
+    B22 result;
+    B22::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B22& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B22::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B22& target) {
+    B22::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B22& target) {
@@ -1034,6 +1380,7 @@ struct B22 {
 };
 
 struct B23 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x17;
 
   int32_t i23;
@@ -1043,7 +1390,7 @@ struct B23 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B23& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B23& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B23::encodeInto(message, writer);
   }
@@ -1057,15 +1404,29 @@ struct B23 {
     writer.writeBool(message.b);
   }
 
-  static B23 decode(const uint8_t *sourceBuffer) {
+  static B23 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B23 result;
-    B23::decodeInto(sourceBuffer, result);
+    B23::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B23& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B23 decode(std::vector<uint8_t> sourceBuffer) {
+    return B23::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B23 decode(::bebop::Reader& reader) {
+    B23 result;
+    B23::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B23& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B23::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B23& target) {
+    B23::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B23& target) {
@@ -1079,6 +1440,7 @@ struct B23 {
 };
 
 struct B24 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x18;
 
   int32_t i24;
@@ -1088,7 +1450,7 @@ struct B24 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B24& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B24& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B24::encodeInto(message, writer);
   }
@@ -1102,15 +1464,29 @@ struct B24 {
     writer.writeBool(message.b);
   }
 
-  static B24 decode(const uint8_t *sourceBuffer) {
+  static B24 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B24 result;
-    B24::decodeInto(sourceBuffer, result);
+    B24::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B24& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B24 decode(std::vector<uint8_t> sourceBuffer) {
+    return B24::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B24 decode(::bebop::Reader& reader) {
+    B24 result;
+    B24::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B24& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B24::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B24& target) {
+    B24::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B24& target) {
@@ -1124,6 +1500,7 @@ struct B24 {
 };
 
 struct B25 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x19;
 
   int32_t i25;
@@ -1133,7 +1510,7 @@ struct B25 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B25& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B25& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B25::encodeInto(message, writer);
   }
@@ -1147,15 +1524,29 @@ struct B25 {
     writer.writeBool(message.b);
   }
 
-  static B25 decode(const uint8_t *sourceBuffer) {
+  static B25 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B25 result;
-    B25::decodeInto(sourceBuffer, result);
+    B25::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B25& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B25 decode(std::vector<uint8_t> sourceBuffer) {
+    return B25::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B25 decode(::bebop::Reader& reader) {
+    B25 result;
+    B25::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B25& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B25::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B25& target) {
+    B25::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B25& target) {
@@ -1169,6 +1560,7 @@ struct B25 {
 };
 
 struct B26 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x1A;
 
   int32_t i26;
@@ -1178,7 +1570,7 @@ struct B26 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B26& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B26& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B26::encodeInto(message, writer);
   }
@@ -1192,15 +1584,29 @@ struct B26 {
     writer.writeBool(message.b);
   }
 
-  static B26 decode(const uint8_t *sourceBuffer) {
+  static B26 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B26 result;
-    B26::decodeInto(sourceBuffer, result);
+    B26::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B26& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B26 decode(std::vector<uint8_t> sourceBuffer) {
+    return B26::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B26 decode(::bebop::Reader& reader) {
+    B26 result;
+    B26::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B26& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B26::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B26& target) {
+    B26::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B26& target) {
@@ -1214,6 +1620,7 @@ struct B26 {
 };
 
 struct B27 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x1B;
 
   int32_t i27;
@@ -1223,7 +1630,7 @@ struct B27 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B27& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B27& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B27::encodeInto(message, writer);
   }
@@ -1237,15 +1644,29 @@ struct B27 {
     writer.writeBool(message.b);
   }
 
-  static B27 decode(const uint8_t *sourceBuffer) {
+  static B27 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B27 result;
-    B27::decodeInto(sourceBuffer, result);
+    B27::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B27& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B27 decode(std::vector<uint8_t> sourceBuffer) {
+    return B27::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B27 decode(::bebop::Reader& reader) {
+    B27 result;
+    B27::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B27& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B27::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B27& target) {
+    B27::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B27& target) {
@@ -1259,6 +1680,7 @@ struct B27 {
 };
 
 struct B28 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x1C;
 
   int32_t i28;
@@ -1268,7 +1690,7 @@ struct B28 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B28& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B28& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B28::encodeInto(message, writer);
   }
@@ -1282,15 +1704,29 @@ struct B28 {
     writer.writeBool(message.b);
   }
 
-  static B28 decode(const uint8_t *sourceBuffer) {
+  static B28 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B28 result;
-    B28::decodeInto(sourceBuffer, result);
+    B28::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B28& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B28 decode(std::vector<uint8_t> sourceBuffer) {
+    return B28::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B28 decode(::bebop::Reader& reader) {
+    B28 result;
+    B28::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B28& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B28::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B28& target) {
+    B28::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B28& target) {
@@ -1304,6 +1740,7 @@ struct B28 {
 };
 
 struct B29 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x1D;
 
   int32_t i29;
@@ -1313,7 +1750,7 @@ struct B29 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B29& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B29& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B29::encodeInto(message, writer);
   }
@@ -1327,15 +1764,29 @@ struct B29 {
     writer.writeBool(message.b);
   }
 
-  static B29 decode(const uint8_t *sourceBuffer) {
+  static B29 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B29 result;
-    B29::decodeInto(sourceBuffer, result);
+    B29::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B29& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B29 decode(std::vector<uint8_t> sourceBuffer) {
+    return B29::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B29 decode(::bebop::Reader& reader) {
+    B29 result;
+    B29::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B29& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B29::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B29& target) {
+    B29::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B29& target) {
@@ -1349,6 +1800,7 @@ struct B29 {
 };
 
 struct B30 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x1E;
 
   int32_t i30;
@@ -1358,7 +1810,7 @@ struct B30 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B30& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B30& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B30::encodeInto(message, writer);
   }
@@ -1372,15 +1824,29 @@ struct B30 {
     writer.writeBool(message.b);
   }
 
-  static B30 decode(const uint8_t *sourceBuffer) {
+  static B30 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B30 result;
-    B30::decodeInto(sourceBuffer, result);
+    B30::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B30& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B30 decode(std::vector<uint8_t> sourceBuffer) {
+    return B30::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B30 decode(::bebop::Reader& reader) {
+    B30 result;
+    B30::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B30& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B30::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B30& target) {
+    B30::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B30& target) {
@@ -1394,6 +1860,7 @@ struct B30 {
 };
 
 struct B31 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x1F;
 
   int32_t i31;
@@ -1403,7 +1870,7 @@ struct B31 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B31& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B31& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B31::encodeInto(message, writer);
   }
@@ -1417,15 +1884,29 @@ struct B31 {
     writer.writeBool(message.b);
   }
 
-  static B31 decode(const uint8_t *sourceBuffer) {
+  static B31 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B31 result;
-    B31::decodeInto(sourceBuffer, result);
+    B31::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B31& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B31 decode(std::vector<uint8_t> sourceBuffer) {
+    return B31::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B31 decode(::bebop::Reader& reader) {
+    B31 result;
+    B31::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B31& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B31::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B31& target) {
+    B31::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B31& target) {
@@ -1439,6 +1920,7 @@ struct B31 {
 };
 
 struct B32 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x20;
 
   int32_t i32;
@@ -1448,7 +1930,7 @@ struct B32 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B32& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B32& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B32::encodeInto(message, writer);
   }
@@ -1462,15 +1944,29 @@ struct B32 {
     writer.writeBool(message.b);
   }
 
-  static B32 decode(const uint8_t *sourceBuffer) {
+  static B32 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B32 result;
-    B32::decodeInto(sourceBuffer, result);
+    B32::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B32& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B32 decode(std::vector<uint8_t> sourceBuffer) {
+    return B32::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B32 decode(::bebop::Reader& reader) {
+    B32 result;
+    B32::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B32& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B32::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B32& target) {
+    B32::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B32& target) {
@@ -1484,6 +1980,7 @@ struct B32 {
 };
 
 struct B33 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x21;
 
   int32_t i33;
@@ -1493,7 +1990,7 @@ struct B33 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B33& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B33& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B33::encodeInto(message, writer);
   }
@@ -1507,15 +2004,29 @@ struct B33 {
     writer.writeBool(message.b);
   }
 
-  static B33 decode(const uint8_t *sourceBuffer) {
+  static B33 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B33 result;
-    B33::decodeInto(sourceBuffer, result);
+    B33::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B33& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B33 decode(std::vector<uint8_t> sourceBuffer) {
+    return B33::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B33 decode(::bebop::Reader& reader) {
+    B33 result;
+    B33::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B33& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B33::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B33& target) {
+    B33::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B33& target) {
@@ -1529,6 +2040,7 @@ struct B33 {
 };
 
 struct B34 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x22;
 
   int32_t i34;
@@ -1538,7 +2050,7 @@ struct B34 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B34& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B34& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B34::encodeInto(message, writer);
   }
@@ -1552,15 +2064,29 @@ struct B34 {
     writer.writeBool(message.b);
   }
 
-  static B34 decode(const uint8_t *sourceBuffer) {
+  static B34 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B34 result;
-    B34::decodeInto(sourceBuffer, result);
+    B34::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B34& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B34 decode(std::vector<uint8_t> sourceBuffer) {
+    return B34::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B34 decode(::bebop::Reader& reader) {
+    B34 result;
+    B34::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B34& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B34::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B34& target) {
+    B34::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B34& target) {
@@ -1574,6 +2100,7 @@ struct B34 {
 };
 
 struct B35 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x23;
 
   int32_t i35;
@@ -1583,7 +2110,7 @@ struct B35 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B35& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B35& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B35::encodeInto(message, writer);
   }
@@ -1597,15 +2124,29 @@ struct B35 {
     writer.writeBool(message.b);
   }
 
-  static B35 decode(const uint8_t *sourceBuffer) {
+  static B35 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B35 result;
-    B35::decodeInto(sourceBuffer, result);
+    B35::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B35& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B35 decode(std::vector<uint8_t> sourceBuffer) {
+    return B35::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B35 decode(::bebop::Reader& reader) {
+    B35 result;
+    B35::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B35& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B35::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B35& target) {
+    B35::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B35& target) {
@@ -1619,6 +2160,7 @@ struct B35 {
 };
 
 struct B36 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x24;
 
   int32_t i36;
@@ -1628,7 +2170,7 @@ struct B36 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B36& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B36& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B36::encodeInto(message, writer);
   }
@@ -1642,15 +2184,29 @@ struct B36 {
     writer.writeBool(message.b);
   }
 
-  static B36 decode(const uint8_t *sourceBuffer) {
+  static B36 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B36 result;
-    B36::decodeInto(sourceBuffer, result);
+    B36::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B36& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B36 decode(std::vector<uint8_t> sourceBuffer) {
+    return B36::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B36 decode(::bebop::Reader& reader) {
+    B36 result;
+    B36::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B36& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B36::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B36& target) {
+    B36::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B36& target) {
@@ -1664,6 +2220,7 @@ struct B36 {
 };
 
 struct B37 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x25;
 
   int32_t i37;
@@ -1673,7 +2230,7 @@ struct B37 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B37& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B37& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B37::encodeInto(message, writer);
   }
@@ -1687,15 +2244,29 @@ struct B37 {
     writer.writeBool(message.b);
   }
 
-  static B37 decode(const uint8_t *sourceBuffer) {
+  static B37 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B37 result;
-    B37::decodeInto(sourceBuffer, result);
+    B37::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B37& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B37 decode(std::vector<uint8_t> sourceBuffer) {
+    return B37::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B37 decode(::bebop::Reader& reader) {
+    B37 result;
+    B37::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B37& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B37::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B37& target) {
+    B37::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B37& target) {
@@ -1709,6 +2280,7 @@ struct B37 {
 };
 
 struct B38 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x26;
 
   int32_t i38;
@@ -1718,7 +2290,7 @@ struct B38 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B38& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B38& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B38::encodeInto(message, writer);
   }
@@ -1732,15 +2304,29 @@ struct B38 {
     writer.writeBool(message.b);
   }
 
-  static B38 decode(const uint8_t *sourceBuffer) {
+  static B38 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B38 result;
-    B38::decodeInto(sourceBuffer, result);
+    B38::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B38& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B38 decode(std::vector<uint8_t> sourceBuffer) {
+    return B38::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B38 decode(::bebop::Reader& reader) {
+    B38 result;
+    B38::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B38& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B38::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B38& target) {
+    B38::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B38& target) {
@@ -1754,6 +2340,7 @@ struct B38 {
 };
 
 struct B39 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x27;
 
   int32_t i39;
@@ -1763,7 +2350,7 @@ struct B39 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B39& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B39& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B39::encodeInto(message, writer);
   }
@@ -1777,15 +2364,29 @@ struct B39 {
     writer.writeBool(message.b);
   }
 
-  static B39 decode(const uint8_t *sourceBuffer) {
+  static B39 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B39 result;
-    B39::decodeInto(sourceBuffer, result);
+    B39::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B39& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B39 decode(std::vector<uint8_t> sourceBuffer) {
+    return B39::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B39 decode(::bebop::Reader& reader) {
+    B39 result;
+    B39::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B39& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B39::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B39& target) {
+    B39::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B39& target) {
@@ -1799,6 +2400,7 @@ struct B39 {
 };
 
 struct B40 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x28;
 
   int32_t i40;
@@ -1808,7 +2410,7 @@ struct B40 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B40& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B40& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B40::encodeInto(message, writer);
   }
@@ -1822,15 +2424,29 @@ struct B40 {
     writer.writeBool(message.b);
   }
 
-  static B40 decode(const uint8_t *sourceBuffer) {
+  static B40 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B40 result;
-    B40::decodeInto(sourceBuffer, result);
+    B40::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B40& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B40 decode(std::vector<uint8_t> sourceBuffer) {
+    return B40::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B40 decode(::bebop::Reader& reader) {
+    B40 result;
+    B40::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B40& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B40::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B40& target) {
+    B40::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B40& target) {
@@ -1844,6 +2460,7 @@ struct B40 {
 };
 
 struct B41 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x29;
 
   int32_t i41;
@@ -1853,7 +2470,7 @@ struct B41 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B41& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B41& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B41::encodeInto(message, writer);
   }
@@ -1867,15 +2484,29 @@ struct B41 {
     writer.writeBool(message.b);
   }
 
-  static B41 decode(const uint8_t *sourceBuffer) {
+  static B41 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B41 result;
-    B41::decodeInto(sourceBuffer, result);
+    B41::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B41& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B41 decode(std::vector<uint8_t> sourceBuffer) {
+    return B41::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B41 decode(::bebop::Reader& reader) {
+    B41 result;
+    B41::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B41& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B41::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B41& target) {
+    B41::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B41& target) {
@@ -1889,6 +2520,7 @@ struct B41 {
 };
 
 struct B42 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x2A;
 
   int32_t i42;
@@ -1898,7 +2530,7 @@ struct B42 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B42& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B42& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B42::encodeInto(message, writer);
   }
@@ -1912,15 +2544,29 @@ struct B42 {
     writer.writeBool(message.b);
   }
 
-  static B42 decode(const uint8_t *sourceBuffer) {
+  static B42 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B42 result;
-    B42::decodeInto(sourceBuffer, result);
+    B42::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B42& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B42 decode(std::vector<uint8_t> sourceBuffer) {
+    return B42::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B42 decode(::bebop::Reader& reader) {
+    B42 result;
+    B42::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B42& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B42::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B42& target) {
+    B42::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B42& target) {
@@ -1934,6 +2580,7 @@ struct B42 {
 };
 
 struct B43 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x2B;
 
   int32_t i43;
@@ -1943,7 +2590,7 @@ struct B43 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B43& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B43& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B43::encodeInto(message, writer);
   }
@@ -1957,15 +2604,29 @@ struct B43 {
     writer.writeBool(message.b);
   }
 
-  static B43 decode(const uint8_t *sourceBuffer) {
+  static B43 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B43 result;
-    B43::decodeInto(sourceBuffer, result);
+    B43::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B43& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B43 decode(std::vector<uint8_t> sourceBuffer) {
+    return B43::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B43 decode(::bebop::Reader& reader) {
+    B43 result;
+    B43::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B43& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B43::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B43& target) {
+    B43::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B43& target) {
@@ -1979,6 +2640,7 @@ struct B43 {
 };
 
 struct B44 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x2C;
 
   int32_t i44;
@@ -1988,7 +2650,7 @@ struct B44 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B44& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B44& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B44::encodeInto(message, writer);
   }
@@ -2002,15 +2664,29 @@ struct B44 {
     writer.writeBool(message.b);
   }
 
-  static B44 decode(const uint8_t *sourceBuffer) {
+  static B44 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B44 result;
-    B44::decodeInto(sourceBuffer, result);
+    B44::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B44& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B44 decode(std::vector<uint8_t> sourceBuffer) {
+    return B44::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B44 decode(::bebop::Reader& reader) {
+    B44 result;
+    B44::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B44& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B44::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B44& target) {
+    B44::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B44& target) {
@@ -2024,6 +2700,7 @@ struct B44 {
 };
 
 struct B45 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x2D;
 
   int32_t i45;
@@ -2033,7 +2710,7 @@ struct B45 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B45& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B45& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B45::encodeInto(message, writer);
   }
@@ -2047,15 +2724,29 @@ struct B45 {
     writer.writeBool(message.b);
   }
 
-  static B45 decode(const uint8_t *sourceBuffer) {
+  static B45 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B45 result;
-    B45::decodeInto(sourceBuffer, result);
+    B45::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B45& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B45 decode(std::vector<uint8_t> sourceBuffer) {
+    return B45::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B45 decode(::bebop::Reader& reader) {
+    B45 result;
+    B45::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B45& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B45::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B45& target) {
+    B45::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B45& target) {
@@ -2069,6 +2760,7 @@ struct B45 {
 };
 
 struct B46 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x2E;
 
   int32_t i46;
@@ -2078,7 +2770,7 @@ struct B46 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B46& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B46& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B46::encodeInto(message, writer);
   }
@@ -2092,15 +2784,29 @@ struct B46 {
     writer.writeBool(message.b);
   }
 
-  static B46 decode(const uint8_t *sourceBuffer) {
+  static B46 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B46 result;
-    B46::decodeInto(sourceBuffer, result);
+    B46::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B46& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B46 decode(std::vector<uint8_t> sourceBuffer) {
+    return B46::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B46 decode(::bebop::Reader& reader) {
+    B46 result;
+    B46::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B46& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B46::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B46& target) {
+    B46::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B46& target) {
@@ -2114,6 +2820,7 @@ struct B46 {
 };
 
 struct B47 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x2F;
 
   int32_t i47;
@@ -2123,7 +2830,7 @@ struct B47 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B47& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B47& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B47::encodeInto(message, writer);
   }
@@ -2137,15 +2844,29 @@ struct B47 {
     writer.writeBool(message.b);
   }
 
-  static B47 decode(const uint8_t *sourceBuffer) {
+  static B47 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B47 result;
-    B47::decodeInto(sourceBuffer, result);
+    B47::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B47& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B47 decode(std::vector<uint8_t> sourceBuffer) {
+    return B47::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B47 decode(::bebop::Reader& reader) {
+    B47 result;
+    B47::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B47& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B47::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B47& target) {
+    B47::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B47& target) {
@@ -2159,6 +2880,7 @@ struct B47 {
 };
 
 struct B48 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x30;
 
   int32_t i48;
@@ -2168,7 +2890,7 @@ struct B48 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B48& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B48& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B48::encodeInto(message, writer);
   }
@@ -2182,15 +2904,29 @@ struct B48 {
     writer.writeBool(message.b);
   }
 
-  static B48 decode(const uint8_t *sourceBuffer) {
+  static B48 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B48 result;
-    B48::decodeInto(sourceBuffer, result);
+    B48::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B48& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B48 decode(std::vector<uint8_t> sourceBuffer) {
+    return B48::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B48 decode(::bebop::Reader& reader) {
+    B48 result;
+    B48::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B48& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B48::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B48& target) {
+    B48::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B48& target) {
@@ -2204,6 +2940,7 @@ struct B48 {
 };
 
 struct B49 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x31;
 
   int32_t i49;
@@ -2213,7 +2950,7 @@ struct B49 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B49& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B49& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B49::encodeInto(message, writer);
   }
@@ -2227,15 +2964,29 @@ struct B49 {
     writer.writeBool(message.b);
   }
 
-  static B49 decode(const uint8_t *sourceBuffer) {
+  static B49 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B49 result;
-    B49::decodeInto(sourceBuffer, result);
+    B49::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B49& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B49 decode(std::vector<uint8_t> sourceBuffer) {
+    return B49::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B49 decode(::bebop::Reader& reader) {
+    B49 result;
+    B49::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B49& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B49::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B49& target) {
+    B49::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B49& target) {
@@ -2249,6 +3000,7 @@ struct B49 {
 };
 
 struct B50 {
+  static const size_t minimalEncodedSize = 41;
   static const uint32_t opcode = 0x32;
 
   int32_t i50;
@@ -2258,7 +3010,7 @@ struct B50 {
   ::bebop::Guid g;
   bool b;
 
-  static void encodeInto(const B50& message, std::vector<uint8_t> &targetBuffer) {
+  static void encodeInto(const B50& message, std::vector<uint8_t>& targetBuffer) {
     ::bebop::Writer writer{targetBuffer};
     B50::encodeInto(message, writer);
   }
@@ -2272,15 +3024,29 @@ struct B50 {
     writer.writeBool(message.b);
   }
 
-  static B50 decode(const uint8_t *sourceBuffer) {
+  static B50 decode(const uint8_t* sourceBuffer, size_t sourceBufferSize) {
     B50 result;
-    B50::decodeInto(sourceBuffer, result);
+    B50::decodeInto(sourceBuffer, sourceBufferSize, result);
     return result;
   }
 
-  static void decodeInto(const uint8_t *sourceBuffer, B50& target) {
-    ::bebop::Reader reader{sourceBuffer};
+  static B50 decode(std::vector<uint8_t> sourceBuffer) {
+    return B50::decode(sourceBuffer.data(), sourceBuffer.size());
+  }
+
+  static B50 decode(::bebop::Reader& reader) {
+    B50 result;
+    B50::decodeInto(reader, result);
+    return result;
+  }
+
+  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, B50& target) {
+    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};
     B50::decodeInto(reader, target);
+  }
+
+  static void decodeInto(std::vector<uint8_t> sourceBuffer, B50& target) {
+    B50::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);
   }
 
   static void decodeInto(::bebop::Reader& reader, B50& target) {

--- a/Laboratory/C++/test/jazz.cpp
+++ b/Laboratory/C++/test/jazz.cpp
@@ -20,9 +20,16 @@ int main() {
     printf("\n");
 
     Library l2;
-    Library::decodeInto(buf.data(), l2);
+    Library::decodeInto(buf, l2);
     printf("%s\n", l2.songs.at(g).title.value().c_str());
     printf("%d\n", l2.songs.at(g).year.value());
     printf("%s\n", l2.songs.at(g).performers.value()[0].name.c_str());
+
+    buf = std::vector<uint8_t> { 123, 123, 123, 123, 123 };
+    try {
+        Library::decodeInto(buf, l2);
+    } catch (bebop::MalformedPacketException& e) {
+        printf("Decoding a malformed packet correctly threw an exception\n");
+    }
 }
 

--- a/Laboratory/C++/test/nested_message.cpp
+++ b/Laboratory/C++/test/nested_message.cpp
@@ -10,7 +10,7 @@ int main()
         OuterM::encodeInto(o, vec);
 
         OuterM o2;
-        OuterM::decodeInto(vec.data(), o2);
+        OuterM::decodeInto(vec, o2);
 
         std::cout << (o2.innerM.value().x.value()) << std::endl;
         std::cout << (o2.innerS.value().y) << std::endl;
@@ -22,7 +22,7 @@ int main()
         OuterS::encodeInto(o, vec);
 
         OuterS o2;
-        OuterS::decodeInto(vec.data(), o2);
+        OuterS::decodeInto(vec, o2);
 
         std::cout << (o2.innerM.x.value()) << std::endl;
         std::cout << (o2.innerS.y) << std::endl;

--- a/Laboratory/C++/test/union_perf_a.cpp
+++ b/Laboratory/C++/test/union_perf_a.cpp
@@ -35,7 +35,7 @@ int main()
             std::vector<uint8_t> buf;
             A::encodeInto(a, buf);
             A a2;
-            A::decodeInto(buf.data(), a2);
+            A::decodeInto(buf, a2);
             sum += std::get<A14>(a2.u.variant).i14;
         }
         auto t2 = high_resolution_clock::now();

--- a/Laboratory/C++/test/union_perf_b.cpp
+++ b/Laboratory/C++/test/union_perf_b.cpp
@@ -34,9 +34,9 @@ int main()
             std::vector<uint8_t> buf;
             B::encodeInto(b, buf);
             B b2;
-            B::decodeInto(buf.data(), b2);
+            B::decodeInto(buf, b2);
             B14 inner2;
-            B14::decodeInto(b2.encodedData.data(), inner2);
+            B14::decodeInto(b2.encodedData, inner2);
             sum += inner2.i14;
         }
         auto t2 = high_resolution_clock::now();

--- a/Runtime/C++/test/test.cpp
+++ b/Runtime/C++/test/test.cpp
@@ -7,7 +7,8 @@
 #include <cstdio>
 
 int main() {
-    bebop::BebopWriter w;
+    std::vector<uint8_t> buffer;
+    bebop::Writer w { buffer };
     const std::string myGuid = "04328465-4290-4bf2-896b-5d05a9084e9b";
     w.writeGuid(bebop::Guid::fromString(myGuid));
     w.writeInt64(12345);
@@ -17,9 +18,7 @@ int main() {
     size_t p = w.reserveMessageLength();
     w.fillMessageLength(p, 0x1234);
 
-    auto buffer = *w.buffer();
-    
-    bebop::BebopReader r { buffer.data() };
+    bebop::Reader r { buffer.data(), buffer.size() };
     std::cout << "guid roundtrip: " << (r.readGuid().toString() == myGuid ? "ok" : "fail") << std::endl;
     std::cout << "int roundtrip: " << (r.readInt64() == 12345 ? "ok" : "fail") << std::endl;
     std::cout << "float roundtrip: " << (fabs(r.readFloat32() - 12.345) < 0.000001 ? "ok" : "fail") << std::endl;


### PR DESCRIPTION
Efficient as it may be to access a buffer without any length checks, this is probably unacceptable if it means decoding an invalid buffer makes the program segfault and crash.

This PR makes the C++ runtime throw a `bebop::MalformedPacketException` when it reaches the end of the buffer prematurely, or when it reads a length prefix larger than the amount of bytes left in the buffer.

Many places that previously accepted a `const uint8_t* sourceBuffer` now need an additional `size_t sourceBufferSize`, so this change breaks those APIs.

---

This PR also introduces codegen for `static const size_t minimalEncodedSize`, which is a lower bound for the wire-format size of a TopLevelDefinition. For example, `minimalEncodedSize` for `struct Musician { string name; Instrument plays; }` is 8: an empty string is 4 bytes on the wire, and an enum is 4 bytes also. @apecoraro suggested that this is useful when trying to estimate how much space to allocate when making a buffer to encode into.