### PR TITLE
Topologically sort definitions in C++ codegen

### DIFF
--- a/Core/Exceptions/Exceptions.cs
+++ b/Core/Exceptions/Exceptions.cs
@@ -144,4 +144,12 @@ namespace Core.Exceptions
         { }
     }
 
+    [Serializable]
+    class CyclicDefinitionsException : SpanException
+    {
+        public CyclicDefinitionsException(Definition definition)
+            : base($"The schema contains an invalid cycle of definitions, involving '{definition.Name}'.", definition.Span, 115)
+        { }
+    }
+
 }

--- a/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
+++ b/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
@@ -348,7 +348,7 @@ namespace Core.Generators.CPlusPlus
                 builder.AppendLine("");
             }
 
-            foreach (var definition in Schema.Definitions.Values)
+            foreach (var definition in Schema.SortedDefinitions())
             {
                 if (!string.IsNullOrWhiteSpace(definition.Documentation))
                 {

--- a/Core/Meta/BebopSchema.cs
+++ b/Core/Meta/BebopSchema.cs
@@ -43,7 +43,7 @@ namespace Core.Meta
             }
 
             // Populate graph / in_degree and find starting nodes (for set S in the algorithm).
-            var s = new Queue<string>();
+            var nextQueue = new Queue<string>();
             foreach (var kv in Definitions)
             {
                 var name = kv.Key;
@@ -51,7 +51,7 @@ namespace Core.Meta
                 var deps = definition.Dependencies();
                 if (deps.Count() == 0)
                 {
-                    s.Enqueue(kv.Key);
+                    nextQueue.Enqueue(name);
                 }
                 foreach (var dep in deps)
                 {
@@ -61,17 +61,17 @@ namespace Core.Meta
             }
 
             // Now run the algorithm.
-            var l = new List<Definition>();
-            while (s.Count > 0)
+            var sortedList = new List<Definition>();
+            while (nextQueue.Count > 0)
             {
-                var n = s.Dequeue();
-                l.Add(Definitions[n]);
-                foreach (var m in graph[n])
+                var name = nextQueue.Dequeue();
+                sortedList.Add(Definitions[name]);
+                foreach (var dependent in graph[name])
                 {
-                    in_degree[m] -= 1;
-                    if (in_degree[m] == 0)
+                    in_degree[dependent] -= 1;
+                    if (in_degree[dependent] == 0)
                     {
-                        s.Enqueue(m);
+                        nextQueue.Enqueue(dependent);
                     }
                 }
             }
@@ -82,7 +82,7 @@ namespace Core.Meta
                 throw new CyclicDefinitionsException(Definitions[cycle.Key]);
             }
 
-            _sortedDefinitions = l;
+            _sortedDefinitions = sortedList;
             return _sortedDefinitions;
         }
 

--- a/Core/Meta/Definition.cs
+++ b/Core/Meta/Definition.cs
@@ -31,6 +31,10 @@ namespace Core.Meta
         /// The inner text of a block comment that preceded the definition.
         /// </summary>
         public string Documentation { get; set; }
+        /// <summary>
+        /// The names of types this definition depends on / refers to.
+        /// </summary>
+        public abstract IEnumerable<string> Dependencies();
     }
 
     /// <summary>
@@ -71,6 +75,17 @@ namespace Core.Meta
         }
 
         public ICollection<IField> Fields { get; }
+
+        public override IEnumerable<string> Dependencies()
+        {
+            foreach (var field in Fields)
+            {
+                if (field.Type is DefinedType dt)
+                {
+                    yield return dt.Name;
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -125,6 +140,8 @@ namespace Core.Meta
             Members = members;
         }
         public ICollection<IField> Members { get; }
+
+        public override IEnumerable<string> Dependencies() => Enumerable.Empty<string>();
     }
 
     public readonly struct UnionBranch
@@ -147,6 +164,8 @@ namespace Core.Meta
         }
 
         public ICollection<UnionBranch> Branches { get; }
+
+        public override IEnumerable<string> Dependencies() => Branches.Select(b => b.Definition.Name);
 
         override public int MinimalEncodedSize(ISchema schema)
         {

--- a/Core/Meta/Interfaces/ISchema.cs
+++ b/Core/Meta/Interfaces/ISchema.cs
@@ -19,6 +19,10 @@ namespace Core.Meta.Interfaces
         /// Validates that the schema is made up of well-formed values.
         /// </summary>
         public void Validate();
+        /// <summary>
+        /// A topologically sorted list of definitions.
+        /// </summary>
+        public List<Definition> SortedDefinitions();
 
     }
 }

--- a/Laboratory/Schemas/toposort.bop
+++ b/Laboratory/Schemas/toposort.bop
@@ -1,0 +1,10 @@
+struct Toposort7 { Toposort6 x; }
+struct Toposort2 { Toposort1 x; }
+struct Toposort9 { Toposort8 x; }
+struct Toposort0 { int32 x; }
+struct Toposort5 { Toposort4 x; }
+struct Toposort1 { Toposort0 x; }
+struct Toposort6 { Toposort5 x; }
+struct Toposort4 { Toposort3 x; }
+struct Toposort3 { Toposort2 x; }
+struct Toposort8 { Toposort7 x; }


### PR DESCRIPTION
This implements [Kahn's algorithm](https://en.wikipedia.org/w/index.php?title=Topological_sorting#Kahn's_algorithm) to find an appropriate order for the definitions in C++ codegen. This way it doesn't matter how you order your schemas in the `.bop` file.

When `SortedDefinitions` is called, it will also detect cycles (like `struct A {B b;} struct B {A a;} `) and throw an exception about them.

`toposort.bop` has an example jumbled chain of dependencies between schemas in it, that gets straightened out in the C++ codegen.