### PR TITLE
decodeInto() returns number of bytes read

### DIFF
--- a/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
+++ b/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
@@ -171,7 +171,7 @@ namespace Core.Generators.CPlusPlus
             builder.Indent(2);
             builder.AppendLine("switch (reader.readByte()) {");
             builder.AppendLine("  case 0:");
-            builder.AppendLine("    return;");
+            builder.AppendLine("    return reader.bytesRead();");
             foreach (var field in definition.Fields)
             {
                 builder.AppendLine($"  case {field.ConstantValue}:");
@@ -180,7 +180,7 @@ namespace Core.Generators.CPlusPlus
             }
             builder.AppendLine("  default:");
             builder.AppendLine("    reader.seek(end);");
-            builder.AppendLine("    return;");
+            builder.AppendLine("    return reader.bytesRead();");
             builder.AppendLine("}");
             builder.Dedent(2);
             builder.AppendLine("}");
@@ -217,7 +217,7 @@ namespace Core.Generators.CPlusPlus
             }
             builder.AppendLine("  default:");
             builder.AppendLine("    reader.seek(end); // do nothing?");
-            builder.AppendLine("    return;");
+            builder.AppendLine("    return reader.bytesRead();");
             builder.AppendLine("}");
             return builder.ToString();
         }
@@ -440,17 +440,18 @@ namespace Core.Generators.CPlusPlus
                         builder.AppendLine($"    return result;");
                         builder.AppendLine("  }");
                         builder.AppendLine("");
-                        builder.AppendLine($"  static void decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, {td.Name}& target) {{");
+                        builder.AppendLine($"  static size_t decodeInto(const uint8_t* sourceBuffer, size_t sourceBufferSize, {td.Name}& target) {{");
                         builder.AppendLine("    ::bebop::Reader reader{sourceBuffer, sourceBufferSize};");
-                        builder.AppendLine($"    {td.Name}::decodeInto(reader, target);");
+                        builder.AppendLine($"    return {td.Name}::decodeInto(reader, target);");
                         builder.AppendLine("  }");
                         builder.AppendLine("");
-                        builder.AppendLine($"  static void decodeInto(std::vector<uint8_t> sourceBuffer, {td.Name}& target) {{");
-                        builder.AppendLine($"    {td.Name}::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);");
+                        builder.AppendLine($"  static size_t decodeInto(std::vector<uint8_t> sourceBuffer, {td.Name}& target) {{");
+                        builder.AppendLine($"    return {td.Name}::decodeInto(sourceBuffer.data(), sourceBuffer.size(), target);");
                         builder.AppendLine("  }");
                         builder.AppendLine("");
-                        builder.AppendLine($"  static void decodeInto(::bebop::Reader& reader, {td.Name}& target) {{");
+                        builder.AppendLine($"  static size_t decodeInto(::bebop::Reader& reader, {td.Name}& target) {{");
                         builder.Append(CompileDecode(td));
+                        builder.AppendLine("    return reader.bytesRead();");
                         builder.AppendLine("  }");
                         builder.AppendLine("");
                         builder.AppendLine("  size_t byteCount() {");

--- a/Core/Meta/Definition.cs
+++ b/Core/Meta/Definition.cs
@@ -76,16 +76,7 @@ namespace Core.Meta
 
         public ICollection<IField> Fields { get; }
 
-        public override IEnumerable<string> Dependencies()
-        {
-            foreach (var field in Fields)
-            {
-                if (field.Type is DefinedType dt)
-                {
-                    yield return dt.Name;
-                }
-            }
-        }
+        public override IEnumerable<string> Dependencies() => Fields.SelectMany(field => field.Type.Dependencies()).Distinct();
     }
 
     /// <summary>

--- a/Core/Meta/Interfaces/TypeBase.cs
+++ b/Core/Meta/Interfaces/TypeBase.cs
@@ -1,4 +1,5 @@
-﻿using Core.Lexer.Tokenization.Models;
+﻿using System.Collections.Generic;
+using Core.Lexer.Tokenization.Models;
 
 namespace Core.Meta.Interfaces
 {
@@ -21,5 +22,10 @@ namespace Core.Meta.Interfaces
         public string AsString { get; }
 
         public override string? ToString() => AsString;
+
+        /// <summary>
+        /// The names of types this definition depends on / refers to.
+        /// </summary>
+        internal abstract IEnumerable<string> Dependencies();
     }
 }

--- a/Core/Meta/Type.cs
+++ b/Core/Meta/Type.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Core.Lexer.Tokenization.Models;
 using Core.Meta.Interfaces;
 
@@ -15,6 +17,8 @@ namespace Core.Meta
         {
             BaseType = baseType;
         }
+
+        internal override IEnumerable<string> Dependencies() => Enumerable.Empty<string>();
     }
 
     /// <summary>
@@ -42,6 +46,8 @@ namespace Core.Meta
         {
             return MemberType is ScalarType st && st.BaseType == BaseType.Float64;
         }
+
+        internal override IEnumerable<string> Dependencies() => MemberType.Dependencies();
     }
 
     /// <summary>
@@ -57,6 +63,8 @@ namespace Core.Meta
             KeyType = keyType;
             ValueType = valueType;
         }
+
+        internal override IEnumerable<string> Dependencies() => KeyType.Dependencies().Concat(ValueType.Dependencies());
     }
 
     class DefinedType : TypeBase
@@ -70,6 +78,8 @@ namespace Core.Meta
         {
             Name = name;
         }
+
+        internal override IEnumerable<string> Dependencies() => new[] { Name };
     }
 
     public static class TypeExtensions

--- a/Laboratory/C++/run_test.sh
+++ b/Laboratory/C++/run_test.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -e
 >&2 echo "Timing bebopc:"
-time dotnet run --project ../../Compiler --cpp "gen/$1.hpp" --files "../Schemas/$1.bop"
+
+if grep -q Microsoft /proc/version; then
+  # Windows: Visual Studio + WSL to run this script
+  bebopc="../../bin/compiler/Windows-Debug/bebopc.exe"
+else
+  # Linux or Mac
+  bebopc="dotnet run --project ../../Compiler"
+fi
+$bebopc --cpp "gen/$1.hpp" --files "../Schemas/$1.bop"
 >&2 echo "Timing C++ compiler:"
 time g++ -std=c++17 test/$1.cpp
 ./a.out

--- a/Laboratory/C++/test/jazz.cpp
+++ b/Laboratory/C++/test/jazz.cpp
@@ -6,7 +6,7 @@
 int main() {
     bebop::Guid g = bebop::Guid::fromString("81c6987b-48b7-495f-ad01-ec20cc5f5be1");
     printf("%s\n", g.toString().c_str());
-    
+
     Song s;
     s.title = "Donna Lee";
     s.year = 1974;
@@ -14,7 +14,7 @@ int main() {
     s.performers = {100, m};
     std::map<bebop::Guid, Song> songs {{g, s}};
     Library l {songs};
-    
+
     std::vector<uint8_t> buf;
     printf("Computed byte count before encoding: %zu\n", l.byteCount());
     Library::encodeInto(l, buf);
@@ -23,7 +23,8 @@ int main() {
     printf("\n");
 
     Library l2;
-    Library::decodeInto(buf, l2);
+    size_t bytesRead = Library::decodeInto(buf, l2);
+    printf("Read %zu bytes\n", bytesRead);
     printf("%s\n", l2.songs.at(g).title.value().c_str());
     printf("%d\n", l2.songs.at(g).year.value());
     printf("%s\n", l2.songs.at(g).performers.value()[0].name.c_str());

--- a/Runtime/C++/src/bebop.hpp
+++ b/Runtime/C++/src/bebop.hpp
@@ -131,7 +131,7 @@ struct Guid {
         return Guid(bytes);
     }
 
-    std::string toString(GuidStyle style = GuidStyle::Dashes) {
+    std::string toString(GuidStyle style = GuidStyle::Dashes) const {
         int size = style == GuidStyle::Dashes ? 36 : 32;
         const char* dash = style == GuidStyle::Dashes ? "-" : "";
         std::unique_ptr<char[]> buffer(new char[size+1]);

--- a/Runtime/C++/src/bebop.hpp
+++ b/Runtime/C++/src/bebop.hpp
@@ -115,7 +115,7 @@ struct Guid {
     static Guid fromString(const std::string& string) {
         uint8_t bytes[16];
         const char* s = string.c_str();
-        
+
         for (const auto i : layout) {
             if (i == dash) {
                 // Skip over a possible dash in the string.
@@ -198,14 +198,16 @@ private:
 #pragma pack(pop)
 
 class Reader {
+    const uint8_t* m_start;
     const uint8_t* m_pointer;
     const uint8_t* m_end;
 public:
-    Reader(const uint8_t* buffer, size_t bufferLength) : m_pointer(buffer), m_end(buffer + bufferLength) {}
+    Reader(const uint8_t* buffer, size_t bufferLength) : m_start(buffer), m_pointer(buffer), m_end(buffer + bufferLength) {}
     Reader(Reader const&) = delete;
     void operator=(Reader const&) = delete;
 
     const uint8_t* pointer() const { return m_pointer; }
+    size_t bytesRead() const { return m_pointer - m_start; }
     void seek(const uint8_t* pointer) { m_pointer = pointer; }
 
     void skip(size_t amount) { m_pointer += amount; }


### PR DESCRIPTION
Also, fix a critical bug in the definition sorting: array and map types should report their dependencies recursively.