### PR TITLE
Support out-of-order union definitions in C++ codegen

### DIFF
--- a/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
+++ b/Core/Generators/CPlusPlus/CPlusPlusGenerator.cs
@@ -83,10 +83,11 @@ namespace Core.Generators.CPlusPlus
             builder.AppendLine($"writer.writeByte(discriminator);");
             builder.AppendLine($"const auto start = writer.length();");
             builder.AppendLine($"switch (discriminator) {{");
+            int i = 0;
             foreach (var branch in definition.Branches)
             {
                 builder.AppendLine($" case {branch.Discriminator}:");
-                builder.AppendLine($"  {branch.Definition.Name}::encodeInto(std::get<{branch.Discriminator - 1}>(message.variant), writer);");
+                builder.AppendLine($"  {branch.Definition.Name}::encodeInto(std::get<{i++}>(message.variant), writer);");
                 builder.AppendLine($"  break;");
             }
             builder.AppendLine($"}}");
@@ -207,13 +208,14 @@ namespace Core.Generators.CPlusPlus
             builder.AppendLine("const auto length = reader.readLengthPrefix();");
             builder.AppendLine("const auto end = reader.pointer() + length + 1;");
             builder.AppendLine("switch (reader.readByte()) {");
+            int i = 0;
             foreach (var branch in definition.Branches)
             {
-                var i = branch.Discriminator - 1;
                 builder.AppendLine($"  case {branch.Discriminator}:");
                 builder.AppendLine($"    target.variant.emplace<{i}>();");
                 builder.AppendLine($"    {branch.Definition.Name}::decodeInto(reader, std::get<{i}>(target.variant));");
                 builder.AppendLine("    break;");
+                i++;
             }
             builder.AppendLine("  default:");
             builder.AppendLine("    reader.seek(end); // do nothing?");

--- a/Laboratory/C++/test/union.cpp
+++ b/Laboratory/C++/test/union.cpp
@@ -1,0 +1,15 @@
+#include <variant>
+#include "../gen/union.hpp"
+
+int main() {
+  WeirdOrder o;
+
+  // We can put a value in...
+  o.variant = TwoComesFirst { 42 };
+
+  // And get it back out
+  TwoComesFirst x = std::get<TwoComesFirst>(o.variant);
+  if (x != 42) return 1;
+
+  return 0;
+}

--- a/Laboratory/Schemas/union.bop
+++ b/Laboratory/Schemas/union.bop
@@ -15,7 +15,9 @@ union U {
     }
 }
 
-union List {
-    1 -> struct Cons { uint32 head; List tail; }
-    2 -> struct Nil {}
+union WeirdOrder {
+    2 -> struct TwoComesFirst { byte b; }
+    4 -> struct ThreeIsSkipped {}
+    1 -> struct OneComesLast {}
 }
+


### PR DESCRIPTION
For example, the codegen for this union was wrong:

```
union WeirdOrder {
    2 -> struct TwoComesFirst { byte b; }
    4 -> struct ThreeIsSkipped {}
    1 -> struct OneComesLast {}
}
```

We generate the type `std::variant<TwoComesFirst, ThreeIsSkipped, OneComesLast>` for the inside of WeirdOrder. However, we were making the incorrect assumption that “discriminator minus one” is always the right index to pass into `std::get<i>()`. This is only correct if the branches are laid out in order like `1 ->` `2 ->` `3 ->`.

This PR fixes that.