### PR TITLE
Fix bebop.json paths bug, make files optional for --check.

### DIFF
--- a/Compiler/CommandLineFlags.cs
+++ b/Compiler/CommandLineFlags.cs
@@ -198,7 +198,7 @@ namespace Compiler
         [CommandLineFlag("files", "Parse and generate code from a list of schemas", "--files [file1] [file2] ...")]
         public List<string>? SchemaFiles { get; private set; }
 
-        [CommandLineFlag("check", "Checks that the provided schema files are valid", "--check [file.bop] [file2.bop] ...", false, false)]
+        [CommandLineFlag("check", "Checks that the provided schema files are valid, or entire project defined by bebop.json if no files provided", "--check [file.bop] [file2.bop] ...", false, false)]
         public List<string>? CheckSchemaFiles { get; private set; }
 
         [CommandLineFlag("check-schema", "Reads a schema from stdin and validates it.", "--check-schema < [schema text]")]

--- a/Compiler/CommandLineFlags.cs
+++ b/Compiler/CommandLineFlags.cs
@@ -41,7 +41,8 @@ namespace Compiler
         public CommandLineFlagAttribute(string name,
             string helpText,
             string usageExample = "",
-            bool isGeneratorFlag = false)
+            bool isGeneratorFlag = false,
+            bool valuesRequired = true)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -55,7 +56,9 @@ namespace Compiler
             HelpText = helpText;
             UsageExample = usageExample;
             IsGeneratorFlag = isGeneratorFlag;
+            ValuesRequired = valuesRequired;
         }
+
 
         /// <summary>
         ///     The name command-line flag. This name is usually a single english word.
@@ -79,6 +82,11 @@ namespace Compiler
         ///     If this property is set to true the attributed command-line flag is used to instantiate a code generator.
         /// </summary>
         public bool IsGeneratorFlag { get; }
+
+        /// <summary>
+        ///     If this property is true, the flag requires values (arguments) to be set.
+        /// </summary>
+        public bool ValuesRequired { get;  }
     }
 
     #endregion
@@ -190,7 +198,7 @@ namespace Compiler
         [CommandLineFlag("files", "Parse and generate code from a list of schemas", "--files [file1] [file2] ...")]
         public List<string>? SchemaFiles { get; private set; }
 
-        [CommandLineFlag("check", "Checks that the provided schema files are valid", "--check [file.bop] [file2.bop] ...")]
+        [CommandLineFlag("check", "Checks that the provided schema files are valid", "--check [file.bop] [file2.bop] ...", false, false)]
         public List<string>? CheckSchemaFiles { get; private set; }
 
         [CommandLineFlag("check-schema", "Reads a schema from stdin and validates it.", "--check-schema < [schema text]")]
@@ -462,7 +470,7 @@ namespace Compiler
                     flag.Property.SetValue(flagStore, true);
                     continue;
                 }
-                if (!parsedFlag.HasValues())
+                if (flag.Attribute.ValuesRequired && !parsedFlag.HasValues())
                 {
                     errorMessage = $"command-line flag '{flag.Attribute.Name}' was not assigned any values.";
                     return false;
@@ -523,6 +531,7 @@ namespace Compiler
         /// <returns>true if the config could be parsed without error, otherwise false.</returns>
         private static bool TryParseConfig(CommandLineFlags flagStore, string? configPath)
         {
+            
             if (string.IsNullOrWhiteSpace(configPath))
             {
                 return false;
@@ -531,6 +540,8 @@ namespace Compiler
             {
                 return false;
             }
+            var configFile = new FileInfo(configPath);
+
             using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
             var root = doc.RootElement;
             if (root.TryGetProperty("inputFiles", out var inputFileElement))
@@ -538,16 +549,20 @@ namespace Compiler
                 flagStore.SchemaFiles = new List<string>(inputFileElement.GetArrayLength());
                 foreach (var fileElement in inputFileElement.EnumerateArray())
                 {
-                    if (fileElement.GetString() is not { } filePath)
+                    if (fileElement.GetString() is not { } filePath || configFile.DirectoryName is null)
                     {
                         continue;
                     }
-                    flagStore.SchemaFiles.Add(filePath);
+                    flagStore.SchemaFiles.Add(Path.GetFullPath(Path.Combine(configFile.DirectoryName, filePath)));
                 }
             }
-            if (root.TryGetProperty("inputDirectory", out var inputDirectoryElement))
+            if (root.TryGetProperty("inputDirectory", out var inputDirectoryElement) && configFile.DirectoryName is not null)
             {
-                flagStore.SchemaDirectory = inputDirectoryElement.GetString();
+                var inputDirectory = inputDirectoryElement.GetString();
+                if (inputDirectory is not null)
+                {
+                    flagStore.SchemaDirectory = Path.GetFullPath(Path.Combine(configFile.DirectoryName, inputDirectory));
+                }
             }
             if (root.TryGetProperty("namespace", out var nameSpaceElement))
             {

--- a/Compiler/CommandLineFlags.cs
+++ b/Compiler/CommandLineFlags.cs
@@ -579,7 +579,11 @@ namespace Compiler
                             .Where(flagAttribute => flagAttribute.Attribute.IsGeneratorFlag &&
                                 flagAttribute.Attribute.Name.Equals(aliasElement.GetString())))
                         {
-                            flagAttribute.Property.SetValue(flagStore, outputElement.GetString());
+                            var outputElementPath = outputElement.GetString();
+                            if (configFile.DirectoryName is not null && outputElementPath is not null)
+                            {
+                                flagAttribute.Property.SetValue(flagStore, Path.GetFullPath(Path.Combine(configFile.DirectoryName, outputElementPath)));
+                            }
                             if (generatorElement.TryGetProperty("langVersion", out var langVersion) && System.Version.TryParse(langVersion.ToString(), out var version))
                             {
 

--- a/Compiler/Properties/PublishProfiles/Publish to node wrapper dir.pubxml
+++ b/Compiler/Properties/PublishProfiles/Publish to node wrapper dir.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Windows-Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishDir>..\Tools\node\tools\windows</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net5.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishTrimmed>False</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/Core/Meta/VersionInfo.cs
+++ b/Core/Meta/VersionInfo.cs
@@ -32,6 +32,6 @@ namespace Core.Meta
         /// <summary>
         /// The human readable version which may contain additional labels.
         /// </summary>
-        public const string Informational = "0.0.1-20210721-1950";
+        public const string Informational = "0.0.1-20210803-1824";
     }
 }

--- a/Core/Meta/VersionInfo.cs
+++ b/Core/Meta/VersionInfo.cs
@@ -32,6 +32,6 @@ namespace Core.Meta
         /// <summary>
         /// The human readable version which may contain additional labels.
         /// </summary>
-        public const string Informational = "0.0.1-20210720-2247";
+        public const string Informational = "0.0.1-20210721-1950";
     }
 }

--- a/Core/Meta/VersionInfo.cs
+++ b/Core/Meta/VersionInfo.cs
@@ -32,6 +32,6 @@ namespace Core.Meta
         /// <summary>
         /// The human readable version which may contain additional labels.
         /// </summary>
-        public const string Informational = "0.0.1-20210526-1755";
+        public const string Informational = "0.0.1-20210720-2247";
     }
 }


### PR DESCRIPTION
Some necessary changes to update the vscode extension to support multiple files. Now --check can be used without any file params to check the entire project using the same semantics as normal compilation. This also fixes a resolution bug with paths inside bebop.json. They were considered relative to cwd, which is bad because it meant you'll get different behavior depending on where you're running bebopc from even using the same exact config file. Now these paths are relative to the config file's own directory. Also adds `checkProject` to the node wrapper, to be used by the vscode extension.

Note that this is a **breaking change**. Build setups will break if they depended upon the old cwd resolution, but changing it is definitely the right thing to do here because the old behavior nullified one of the greatest advantages of the whole recursive config search system: the ability to get the same behavior from the same config no matter where you run the command.

Also includes a publish config that drops output directly in the node wrapper's tools directory, for easy testing.