### PR TITLE
Correct TS date representation

### DIFF
--- a/Laboratory/Integration/run_test.sh
+++ b/Laboratory/Integration/run_test.sh
@@ -23,12 +23,12 @@ echo "Testing that all implementations can decode all encodings..."
 # rust first because it has the most useful errors
 cargo run --manifest-path Rust/Cargo.toml -q --example decode -- rs.enc || fail "Rust decode failed."
 cargo run --manifest-path Rust/Cargo.toml -q --example decode -- cs.enc || fail "Rust failed to decode decode c#."
-#cargo run --manifest-path Rust/Cargo.toml -q --example decode -- ts.enc || fail "Rust failed to decode decode ts."
+cargo run --manifest-path Rust/Cargo.toml -q --example decode -- ts.enc || fail "Rust failed to decode decode ts."
 cargo run --manifest-path Rust/Cargo.toml -q --example decode -- cpp.enc || fail "Rust failed to decode decode c++."
 
 dotnet run decode cs.enc || fail "C# decode failed."
 dotnet run decode rs.enc || fail "C# failed to decode rust."
-#dotnet run decode ts.enc || fail "C# failed to decode ts."
+dotnet run decode ts.enc || fail "C# failed to decode ts."
 dotnet run decode cpp.enc || fail "C# failed to decode c++."
 
 npx ts-node decode.ts ts.enc || fail "TypeScript decode failed."
@@ -39,7 +39,7 @@ npx ts-node decode.ts cpp.enc || fail "TypeScript failed to decode c++."
 g++ --std=c++17 decode.cpp
 ./a.out cpp.enc || fail "C++ decode failed"
 ./a.out rs.enc || fail "C++ failed to decode rust"
-#./a.out ts.enc || fail "C++ failed to decode ts"
+./a.out ts.enc || fail "C++ failed to decode ts"
 ./a.out cs.enc || fail "C++ failed to decode c#"
 rm -f ./a.out
 

--- a/Runtime/C++/src/bebop.hpp
+++ b/Runtime/C++/src/bebop.hpp
@@ -422,7 +422,7 @@ public:
     }
 
     void writeDate(TickDuration duration) {
-        writeUint64(duration.count() + ticksBetweenEpochs);
+        writeUint64((duration.count() + ticksBetweenEpochs) & 0x3fffffffffffffff);
     }
 
     /// Reserve some space to write a message's length prefix, and return its index.

--- a/Runtime/TypeScript/index.ts
+++ b/Runtime/TypeScript/index.ts
@@ -11,8 +11,8 @@ const asciiToHex = [
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0
 ];
 
-const ticksBetweenEpochs = BigInt("621355968000000000");
-const dateMask = BigInt("0x3fffffffffffffff");
+const ticksBetweenEpochs = 621355968000000000n;
+const dateMask = 0x3fffffffffffffffn;
 const emptyByteArray = new Uint8Array(0);
 const emptyString = "";
 const byteToHex: string[] = []; // A lookup table: ['00', '01', ..., 'ff']
@@ -332,13 +332,13 @@ export class BebopView {
 
     readDate(): Date {
         const ticks = this.readUint64() & dateMask;
-        const ms = (ticks - ticksBetweenEpochs) / BigInt("10000");
+        const ms = (ticks - ticksBetweenEpochs) / 10000n;
         return new Date(Number(ms));
     }
 
     writeDate(date: Date) {
         const ms = BigInt(date.getTime());
-        const ticks = ms * BigInt("10000") + ticksBetweenEpochs;
+        const ticks = ms * 10000n + ticksBetweenEpochs;
         this.writeUint64(ticks & dateMask);
     }
 

--- a/Runtime/TypeScript/index.ts
+++ b/Runtime/TypeScript/index.ts
@@ -330,12 +330,21 @@ export class BebopView {
 
     readDate(): Date {
         const low = this.readUint32();
-        const high = this.readUint32() & 0x3fffffff;
-        const msSince1AD = 429496.7296 * high + 0.0001 * low;
-        return new Date(msSince1AD - 62135596800000);
+        const high = this.readUint32();
+        const highn = high & 0x3fffffff;
+        const msSince1AD = 429496.7296 * highn + 0.0001 * low;
+        let date = new Date(msSince1AD - 62135596800000);
+        date["__bebopLow"] = low;
+        date["__bebopHigh"] = high;
+        return date;
     }
 
     writeDate(date: Date) {
+        if ("__bebopLow" in date && "__bebopHigh" in date) {
+            this.writeUint32(date["__bebopLow"]);
+            this.writeUint32(date["__bebopHigh"]);
+            return;
+        }
         const ms = date.getTime();
         const msSince1AD = ms + 62135596800000;
         const low = msSince1AD % 429496.7296 * 10000 | 0;


### PR DESCRIPTION
Fixes #147

Currently if you encode and decode in this order C# -> TS -> C#, the TS runtime will round the date value slightly. If you go TS -> C# -> TS no change will be observed. The encoding itself is valid, but the runtime is loosing some precision because the JS `Date` type uses a 64-bit float to store the number of MS since the Unix epoch.

So the fix is to use a more precise Date type such as a BigInt or two numbers with high/low splits and allow casting to a JS date type, but it does mean it will be a breaking change.