### PR TITLE
integration test: make sure the encoder writes in BINARY MODE to stdout on all platforms

### DIFF
--- a/Laboratory/Integration/encode.cpp
+++ b/Laboratory/Integration/encode.cpp
@@ -1,11 +1,18 @@
 #include <cstdio>
 #include <vector>
+#if defined(_WIN32) || defined(WIN32) || defined(WIN64)
+#include <fcntl.h>
+#include <io.h>
+#endif
 #include "makelib.hpp"
 
 int main()
 {
+  _setmode(_fileno(stdout), _O_BINARY);
+
   std::vector<uint8_t> buffer;
   Library::encodeInto(make_library(), buffer);
+
   std::fwrite(buffer.data(), sizeof(uint8_t), buffer.size(), stdout);
   return 0;
 }

--- a/Laboratory/Integration/encode.cpp
+++ b/Laboratory/Integration/encode.cpp
@@ -8,8 +8,9 @@
 
 int main()
 {
+#if defined(_WIN32) || defined(WIN32) || defined(WIN64)
   _setmode(_fileno(stdout), _O_BINARY);
-
+#endif
   std::vector<uint8_t> buffer;
   Library::encodeInto(make_library(), buffer);
 


### PR DESCRIPTION
integration test: make sure the encoder writes in BINARY MODE to stdout on all platforms or the tests will all fail on MS Windows (which does implicit LF->CRLF conversion in the stdio streams).

Without this fix, the `run_tests.sh` IntegrationTest script will certainly fail on Windows due to a corrupted length in the encoded data.

