### PR TITLE
Add deref for u8 slice wrapper

### DIFF
--- a/Runtime/Rust/Cargo.lock
+++ b/Runtime/Rust/Cargo.lock
@@ -23,15 +23,16 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 name = "bebop"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "criterion",
  "itertools",
 ]
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"


### PR DESCRIPTION
Noticed this lovely code in one of our repos
```
let data = match chunk.data {
    SliceWrapper::Raw(data) => data,
    SliceWrapper::Cooked(data) => data,
};
```

and figured we should support `Deref` for `u8` slice wrappers. That said, we may want to also consider not using slice wrappers for u8 types, but this was a super easy change.