### PR TITLE
Fix JavaScript syntax for Safari

### DIFF
--- a/Runtime/TypeScript/index.ts
+++ b/Runtime/TypeScript/index.ts
@@ -32,7 +32,7 @@ export class BebopRuntimeError extends Error {
 }
 
 export class BebopView {
-    private static textDecoder = new TextDecoder;
+    private static textDecoder = new TextDecoder();
     private static writeBuffer: Uint8Array = new Uint8Array(256);
     private static writeBufferView: DataView = new DataView(BebopView.writeBuffer.buffer);
     private static instance: BebopView;


### PR DESCRIPTION
It looks like Safari doesn't like `new TextDecoder` without parentheses after it.

![image](https://user-images.githubusercontent.com/16232127/149582419-9335f5bb-948f-4f2b-9ee7-7fe561e44225.png)
