### PR TITLE
feature(tool): installation script for Unix systems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -358,8 +358,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
       - name: Stage Website
-        run: mkdir -p homepage/repl && cp -a bebop-repl-${{ steps.dotenv.outputs.version }}/. homepage/repl
-
+        run: |
+          mkdir -p homepage/repl && cp -a bebop-repl-${{ steps.dotenv.outputs.version }}/. homepage/repl
+          sed 's/0.0.0/${{ steps.dotenv.outputs.version }}/' ${{env.TOOLS_ROOT}}/bash/install.sh > homepage/install.sh
+          
       - name: Publish Website
         uses: jakejarvis/s3-sync-action@master
         env:

--- a/Tools/bash/install.sh
+++ b/Tools/bash/install.sh
@@ -274,10 +274,10 @@ download() {
     local url=$1
     local filename=$2
     if ! result=$(
-        if [[ -x "$(which wgett)" ]]; then
+        if [[ -x "$(which wget)" ]]; then
             wget -O "${filename}" "${url}" 2>&1
         elif [[ -x "$(which curl)" ]]; then
-            curl -fL -o "${filename}" "${url}" 2>&1
+            curl -fLO "${filename}" "${url}" 2>&1
         fi
     ); then
         local error_message
@@ -332,13 +332,7 @@ EOABORT
 extract() {
     local filename=$1
     local destination=$2
-    if ! result=$(
-        if [[ -x "$(which tar)" ]]; then
-            sudo tar -zxpf "${filename}" -C "${destination}" 2>&1
-        elif [[ -x "$(which unzip)" ]]; then
-            sudo unzip -qq -o -j "${filename}" -d "${destination}" 2>&1
-        fi
-    ); then
+    if ! result=$(sudo unzip -X -qq -o -j "${filename}" -d "${destination}" 2>&1); then
         abort "$(
             cat <<EOABORT
 ${ERROR_UTF8} 
@@ -374,8 +368,8 @@ if ! command -v curl >/dev/null && ! command -v wget >/dev/null; then
     abort "$COLLISION_UTF8} You must install either ${tty_underline}${tty_white}cURL${tty_reset} or ${tty_underline}${tty_white}wget${tty_reset} to use this script."
 fi
 
-if ! command -v tar >/dev/null && ! command -v unzip >/dev/null; then
-    abort "$COLLISION_UTF8} You must install either ${tty_underline}${tty_white}tar${tty_reset} or ${tty_underline}${tty_white}unzip${tty_reset} to use this script."
+if ! command -v unzip >/dev/null; then
+    abort "$COLLISION_UTF8} You must install ${tty_underline}${tty_white}unzip${tty_reset} to use this script."
 fi
 
 BEBOPC_PREFIX="/usr/local"
@@ -473,10 +467,7 @@ point "${UNICORN_UTF8} Downloading and installing bebopc (${BEBOPC_VERSION})..."
 
     echo -ne "- ${tty_bold}Creating temp file${tty_reset} "
 
-    # work around the fact macOS does not support
-    # XXXXX formatting with sufixes
-    temp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t "$(uuid)")
-    temp_file=$(mktemp "${temp_dir}$(uuid)".zip 2>/dev/null)
+    temp_file=$(mktemp)
     readonly temp_file
     # Bail out if the temp file wasn't created successfully.
     if [ ! -e "$temp_file" ]; then

--- a/Tools/bash/install.sh
+++ b/Tools/bash/install.sh
@@ -475,7 +475,8 @@ point "${UNICORN_UTF8} Downloading and installing bebopc (${BEBOPC_VERSION})..."
 
     # work around the fact macOS does not support
     # XXXXX formatting with sufixes
-    temp_file=$(mktemp "${TMPDIR}$(uuid)".zip 2>/dev/null)
+    temp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t "$(uuid)")
+    temp_file=$(mktemp "${temp_dir}$(uuid)".zip 2>/dev/null)
     readonly temp_file
     # Bail out if the temp file wasn't created successfully.
     if [ ! -e "$temp_file" ]; then

--- a/Tools/bash/install.sh
+++ b/Tools/bash/install.sh
@@ -1,0 +1,562 @@
+#!/bin/bash
+#
+# Bebop: an extremely simple, fast, efficient, cross-platform serialization format
+# this script is responsible for installing /updating the Bebop compiler
+# https://github.com/rainwayapp/bebop
+#
+# The Apache License 2.0 License
+#
+# Copyright (c) 2017 Rainway, Inc.
+
+set -u
+
+abort() {
+    printf "%s\n" "$@"
+    exit 1
+}
+
+# Fail fast with a concise message when not using bash
+# Single brackets are needed here for POSIX compatibility
+if [ -z "${BASH_VERSION:-}" ]; then
+    abort "Bash is required to use this script."
+fi
+
+### Constants
+readonly BEBOPC_VERSION="${1:-2.3.1}"
+readonly BEBOP_RELEASE_URL="https://api.github.com/repos/rainwayapp/bebop/releases/tags/v${BEBOPC_VERSION}"
+
+readonly ARM64_ISSUE_LINK="https://github.com/RainwayApp/bebop/issues/185"
+
+### string formatters
+
+# listen, emojis are a way of life
+COLLISION_UTF8=$'\360\237\222\245'
+NOGO_UTF8=$'\360\237\231\205'
+LOOKING_UTF8=$'\360\237\247\220'
+GLASS_UTF8=$'\360\237\224\215'
+ROCKET_UTF8=$'\360\237\232\200'
+ABORT_UTF8=$'\360\237\232\253'
+CONSTRUCTION_UTF8=$'\360\237\232\247'
+SUCCESS_UTF8=$'\342\234\205'
+ERROR_UTF8=$'\342\235\214'
+HAPPY_UTF8=$'\360\237\230\200'
+UNICORN_UTF8=$'\360\237\246\204'
+FIRE_UTF8=$'\xF0\x9F\x94\xA5'
+LOCK_UTF8=$'\360\237\224\222'
+EYES_UTF8=$'\360\237\221\200'
+
+if [[ -t 1 ]]; then
+    tty_escape() { printf "\033[%sm" "$1"; }
+else
+    tty_escape() { :; }
+fi
+tty_mkbold() { tty_escape "1;$1"; }
+tty_underline="$(tty_escape "4;39")"
+tty_blue="$(tty_mkbold 34)"
+tty_white="$(tty_mkbold 37)"
+tty_red="$(tty_mkbold 31)"
+tty_bold="$(tty_mkbold 39)"
+tty_reset="$(tty_escape 0)"
+
+shell_join() {
+    local arg
+    printf "%s" "$1"
+    shift
+    for arg in "$@"; do
+        printf " "
+        printf "%s" "${arg// /\ }"
+    done
+}
+
+chomp() {
+    local spaces="${2:-0}"
+    printf "%*s%s" "$spaces" '' "${1/"$'\n'"/}"
+}
+
+point() {
+    printf "${tty_blue}==>${tty_bold} %s${tty_reset}\n" "$(shell_join "$@")"
+}
+
+warn() {
+    printf "${tty_red}Warning${tty_reset}: %s\n" "$(chomp "$1")"
+}
+
+### interactivity checks
+
+# Check if script is run with force-interactive mode in CI
+if [[ -n "${CI-}" && -n "${INTERACTIVE-}" ]]; then
+    abort "${ABORT_UTF8} Cannot run force-interactive mode in CI."
+fi
+
+# Check if both `INTERACTIVE` and `NONINTERACTIVE` are set
+# Always use single-quoted strings with `exp` expressions
+# shellcheck disable=SC2016
+if [[ -n "${INTERACTIVE-}" && -n "${NONINTERACTIVE-}" ]]; then
+    abort 'Both `$INTERACTIVE` and `$NONINTERACTIVE` are set. Please unset at least one variable and try again.'
+fi
+
+# Check if script is run non-interactively (e.g. CI)
+# If it is run non-interactively we should not prompt for passwords.
+# Always use single-quoted strings with `exp` expressions
+# shellcheck disable=SC2016
+if [[ -z "${NONINTERACTIVE-}" ]]; then
+    if [[ -n "${CI-}" ]]; then
+        warn 'Running in non-interactive mode because `$CI` is set.'
+        NONINTERACTIVE=1
+    elif [[ ! -t 0 ]]; then
+        if [[ -z "${INTERACTIVE-}" ]]; then
+            warn 'Running in non-interactive mode because `stdin` is not a TTY.'
+            NONINTERACTIVE=1
+        else
+            warn 'Running in interactive mode despite `stdin` not being a TTY because `$INTERACTIVE` is set.'
+        fi
+    fi
+else
+    point 'Running in non-interactive mode because `$NONINTERACTIVE` is set.'
+fi
+
+### fetch OS info
+
+# don't throw on no case matches (so we can handle it)
+shopt -s nocasematch
+
+# Cache the output of uname so we don't have to spawn it multiple times.
+IFS=" " read -ra uname <<<"$(uname -srm)"
+
+# get OS name
+kernel_name="${uname[0]}"
+case $kernel_name in
+Darwin) os=mac ;;
+Linux | GNU*)
+    os=linux
+    ;;
+*)
+    abort "$COLLISION_UTF8} Unsupported OS detected: '${tty_underline}${tty_white}$kernel_name${tty_reset}', aborting..."
+    ;;
+esac
+unset kernel_name
+readonly os
+
+# get OS version
+os_version="${uname[1]}"
+if [[ "$os" == "mac" ]]; then
+    # OS/X tries really hard to hand back programs the fake "10.16" version number rather than the true "11.0.X" one.
+    export SYSTEM_VERSION_COMPAT=0
+    IFS=$'\n' read -d "" -ra sw_vers <<<"$(awk -F'<|>' '/key|string/ {print $3}' \
+        "/System/Library/CoreServices/SystemVersion.plist")"
+    for ((i = 0; i < ${#sw_vers[@]}; i += 2)); do
+        case ${sw_vers[i]} in
+        ProductVersion) os_version=${sw_vers[i + 1]} ;;
+        esac
+    done
+fi
+readonly os_version
+
+# get OS arch
+kernel_arch="${uname[2]}"
+case $kernel_arch in
+x86_64 | amd64)
+    os=x64
+    ;;
+arm64 | aarch64)
+    os_arch=arm64
+    ;;
+*)
+    abort "$COLLISION_UTF8} Unsupported OS architecture detected: '${tty_underline}${tty_white}$kernel_arch${tty_reset}', aborting..."
+    ;;
+esac
+unset kernel_arch
+readonly os_arch
+
+readonly system_info="${tty_underline}${tty_white}$os $os_version ($os_arch)${tty_reset}"
+
+# OS support checks
+
+### Linux has no x86_64 emulation so the current artifacts won't work
+if [[ $os_arch == "arm64" && $os == "linux" ]]; then
+    abort "$(
+        cat <<EOABORT
+${CONSTRUCTION_UTF8} The Bebop compiler does not currently support ARM64 flavors of Linux.
+
+Unlike macOS and Windows, the Linux kernel does not have built-in x86_64 emulation.
+
+ARM64 builds of bebopc are on the way: ${tty_underline}${tty_white}${ARM64_ISSUE_LINK}${tty_reset}
+
+Please subscribe to the issue to know when ARM64 native builds are available.
+
+Your system: ${system_info}
+
+EOABORT
+    )"
+fi
+
+unset HAVE_SUDO_ACCESS # unset this from the environment
+
+have_sudo_access() {
+    if [[ ! -x "/usr/bin/sudo" ]]; then
+        return 1
+    fi
+
+    local -a SUDO=("/usr/bin/sudo")
+    if [[ -n "${SUDO_ASKPASS-}" ]]; then
+        SUDO+=("-A")
+    elif [[ -n "${NONINTERACTIVE-}" ]]; then
+        SUDO+=("-n")
+    fi
+
+    if [[ -z "${HAVE_SUDO_ACCESS-}" ]]; then
+        if [[ -n "${NONINTERACTIVE-}" ]]; then
+            "${SUDO[@]}" -l mkdir &>/dev/null
+        else
+            "${SUDO[@]}" -v && "${SUDO[@]}" -l mkdir &>/dev/null
+        fi
+        HAVE_SUDO_ACCESS="$?"
+    fi
+
+    if [[ $os != "linux" ]] && [[ "${HAVE_SUDO_ACCESS}" -ne 0 ]]; then
+        abort "${FIRE_UTF8} Need sudo access on macOS (e.g. the user ${USER} needs to be an Administrator)!"
+    fi
+
+    return "${HAVE_SUDO_ACCESS}"
+}
+
+### Helper functions
+
+major_minor() {
+    echo "${1%%.*}.$(
+        x="${1#*.}"
+        echo "${x%%.*}"
+    )"
+}
+version_gt() {
+    [[ "${1%.*}" -gt "${2%.*}" ]] || [[ "${1%.*}" -eq "${2%.*}" && "${1#*.}" -gt "${2#*.}" ]]
+}
+version_ge() {
+    [[ "${1%.*}" -gt "${2%.*}" ]] || [[ "${1%.*}" -eq "${2%.*}" && "${1#*.}" -ge "${2#*.}" ]]
+}
+version_lt() {
+    [[ "${1%.*}" -lt "${2%.*}" ]] || [[ "${1%.*}" -eq "${2%.*}" && "${1#*.}" -lt "${2#*.}" ]]
+}
+
+uuid() {
+    local N B C='89ab'
+
+    for ((N = 0; N < 16; ++N)); do
+        B=$((RANDOM % 256))
+
+        case $N in
+        6)
+            printf '4%x' $((B % 16))
+            ;;
+        8)
+            printf '%c%x' ${C:$RANDOM%${#C}:1} $((B % 16))
+            ;;
+        3 | 5 | 7 | 9)
+            printf '%02x' $B
+            ;;
+        *)
+            printf '%02x' $B
+            ;;
+        esac
+    done
+
+    echo
+}
+
+ring_bell() {
+    # Use the shell's audible bell.
+    if [[ -t 1 ]]; then
+        printf "\a"
+    fi
+}
+
+download() {
+    local url=$1
+    local filename=$2
+    if ! result=$(
+        if [[ -x "$(which wgett)" ]]; then
+            wget -O "${filename}" "${url}" 2>&1
+        elif [[ -x "$(which curl)" ]]; then
+            curl -fL -o "${filename}" "${url}" 2>&1
+        fi
+    ); then
+        local error_message
+        error_message=$(echo "$result" | grep -o -i "failed.*\|error.*\|command.*")
+
+        abort "$(
+            cat <<EOABORT
+${ERROR_UTF8} 
+   - ${tty_red}Unable to download '${url}'${tty_reset} (exit code 1):
+     - ${error_message}
+EOABORT
+        )"
+    fi
+
+}
+
+fetch_release_url() {
+    local target_os_name="$1"
+    local target_os_arch="$2"
+    readonly target="${target_os_name}${target_os_arch}.zip"
+    local exit_code=1
+    if result=$(
+        if [[ -x "$(which wget)" ]]; then
+            wget -O - "${BEBOP_RELEASE_URL}" 2>&1
+        elif [[ -x "$(which curl)" ]]; then
+            curl -fL "${BEBOP_RELEASE_URL}" 2>&1
+        fi
+    ); then
+        local release_url
+        release_url="$(echo "$result" | grep -E 'browser_download_url' | grep "${target}" | cut -d '"' -f 4)"
+        if [[ -n "$release_url" ]]; then
+            echo "$release_url"
+            exit 0
+        fi
+    else
+        exit_code=$?
+    fi
+
+    local error_message
+    error_message=$(echo "$result" | grep -o -i "failed.*\|error.*\|command.*")
+
+    abort "$(
+        cat <<EOABORT
+${ERROR_UTF8} 
+   - ${tty_red}Unable to locate release artifact for bebopc${tty_reset} ${tty_underline}${tty_white}$BEBOPC_VERSION${tty_reset} (exit code ${exit_code}):
+     - $error_message
+EOABORT
+    )"
+
+}
+
+extract() {
+    local filename=$1
+    local destination=$2
+    if ! result=$(
+        if [[ -x "$(which tar)" ]]; then
+            sudo tar -zxpf "${filename}" -C "${destination}" 2>&1
+        elif [[ -x "$(which unzip)" ]]; then
+            sudo unzip -qq -o -j "${filename}" -d "${destination}" 2>&1
+        fi
+    ); then
+        abort "$(
+            cat <<EOABORT
+${ERROR_UTF8} 
+ - ${tty_red}Failed to install bebopc to ${BEBOPC_PREFIX}/bin${tty_reset}:
+   - ${result}
+EOABORT
+        )"
+    else
+        # cleanup the archive after successful extraction
+        rm -f "$filename" &>/dev/null
+    fi
+}
+
+# USER isn't always set so provide a fall back for the installer and subprocesses.
+if [[ -z "${USER-}" ]]; then
+    USER="$(chomp "$(id -un)")"
+    export USER
+fi
+
+# Invalidate sudo timestamp before exiting (if it wasn't active before).
+if [[ -x /usr/bin/sudo ]] && ! /usr/bin/sudo -n -v 2>/dev/null; then
+    trap '/usr/bin/sudo -k' EXIT
+fi
+
+# Things can fail later if `pwd` doesn't exist.
+# Also sudo prints a warning message for no good reason
+cd "/usr" || exit 1
+
+####################################################################### Install Script
+
+point "${GLASS_UTF8} Checking for dependencies..."
+if ! command -v curl >/dev/null && ! command -v wget >/dev/null; then
+    abort "$COLLISION_UTF8} You must install either ${tty_underline}${tty_white}cURL${tty_reset} or ${tty_underline}${tty_white}wget${tty_reset} to use this script."
+fi
+
+if ! command -v tar >/dev/null && ! command -v unzip >/dev/null; then
+    abort "$COLLISION_UTF8} You must install either ${tty_underline}${tty_white}tar${tty_reset} or ${tty_underline}${tty_white}unzip${tty_reset} to use this script."
+fi
+
+BEBOPC_PREFIX="/usr/local"
+
+# shellcheck disable=SC2016
+point "${LOCK_UTF8} Checking for \`sudo\` access (which may request your password)..."
+if [[ $os != "linux" ]]; then
+    have_sudo_access
+elif [[ -n "${NONINTERACTIVE-}" ]] && ! have_sudo_access; then
+    abort "${NOGO_UTF8} Insufficient permissions to install bebopc to \"${BEBOPC_PREFIX}\"."
+fi
+
+# Lets enforce good hygeine / practices and abort if the user has executed this script with sudo
+# Especially since this script is most likely being piped in over the network
+if [[ "${EUID:-${UID}}" == "0" ]]; then
+    # Allow Azure Pipelines/GitHub Actions/Docker/Concourse/Kubernetes to do everything as root (as it's normal there)
+    if ! [[ -f /proc/1/cgroup ]] ||
+        ! grep -E "azpl_job|actions_job|docker|garden|kubepods" -q /proc/1/cgroup; then
+        abort "${NOGO_UTF8} ${tty_red}Don't run this as root!${tty_reset}"
+    fi
+fi
+
+if [[ -d "${BEBOPC_PREFIX}" && ! -x "${BEBOPC_PREFIX}" ]]; then
+    abort "$(
+        cat <<EOABORT
+${LOOKING_UTF8} The bebopc prefix ${tty_underline}${BEBOPC_PREFIX}${tty_reset} exists but is not searchable.
+If this is not intentional, please restore the default permissions and
+try running the installer again:
+    ${tty_underline}${tty_white}sudo chmod 775 ${BEBOPC_PREFIX}${tty_reset}
+EOABORT
+    )"
+fi
+
+# check if bebopc is already installed
+if [[ -x "$(which bebopc)" ]]; then
+    bebopc_version_output="$(bebopc --version 2>/dev/null)"
+    readonly bebopc_version_output
+    readonly bebopc_name_and_version="${bebopc_version_output%% (*}"
+    readonly installed_bebopc_version="${bebopc_name_and_version##* }"
+    # exit when the remote version of bebopc is the same as the currently installed version
+    if [[ "${installed_bebopc_version}" == "${BEBOPC_VERSION}" ]]; then
+        point "${ROCKET_UTF8} ${tty_underline}${tty_white}$bebopc_name_and_version${tty_reset} is already installed and up-to-date"
+        exit 0
+    fi
+    # abort when the remote version is less than the installed version.
+    # downgrading an install could change code generation
+    if version_lt "${BEBOPC_VERSION}" "${installed_bebopc_version}"; then
+        abort "$(
+            cat <<EOABORT
+$COLLISION_UTF8} ${tty_underline}${tty_white}$bebopc_name_and_version${tty_reset} is already installed,
+and a higher version than targeted ${tty_underline}${tty_white}${BEBOPC_VERSION}${tty_reset}.
+
+Please uninstall bebopc and try again.
+
+EOABORT
+        )"
+    fi
+
+    # warn and proceed if we're updating rather than installing
+    # this is a warning because version changes may introduce code generator changes
+    if version_lt "${installed_bebopc_version}" "${BEBOPC_VERSION}"; then
+        warn "${tty_underline}${tty_white}$bebopc_name_and_version${tty_reset} will be upgraded to ${tty_underline}${tty_white}${BEBOPC_VERSION}${tty_reset}"
+    fi
+
+else
+    point "${EYES_UTF8} This script will install:"
+    echo "- ${BEBOPC_PREFIX}/bin/bebopc"
+fi
+
+if [[ $os_arch == "arm64" && ($os == "mac" || $os == "windows") ]]; then
+    warn "$(
+        cat <<EOS
+${CONSTRUCTION_UTF8} The x86_64 version of bebopc will be used.
+Native ARM64 builds of bebopc are on the way: ${tty_underline}${tty_white}${ARM64_ISSUE_LINK}${tty_reset}
+
+Please subscribe to the issue to know when ARM64 native builds are available.
+
+Your system: ${system_info}
+
+EOS
+    )"
+fi
+
+point "${UNICORN_UTF8} Downloading and installing bebopc (${BEBOPC_VERSION})..."
+(
+
+    echo -ne "- ${tty_bold}Locating release${tty_reset} "
+
+    if ! release_url=$(fetch_release_url "$os" "64"); then
+        # should be the error if fetch_release_url failed
+        abort "$release_url"
+    fi
+
+    echo -e "${SUCCESS_UTF8}"
+
+    echo -ne "- ${tty_bold}Creating temp file${tty_reset} "
+
+    # work around the fact macOS does not support
+    # XXXXX formatting with sufixes
+    temp_file=$(mktemp "${TMPDIR}$(uuid)".zip 2>/dev/null)
+    readonly temp_file
+    # Bail out if the temp file wasn't created successfully.
+    if [ ! -e "$temp_file" ]; then
+        abort "$(
+            cat <<EOABORT
+${ERROR_UTF8} 
+    ${tty_red}Failed to create temporary file${tty_reset}
+EOABORT
+        )"
+    fi
+
+    echo -e "${SUCCESS_UTF8}"
+    echo -ne "- ${tty_bold}Downloading${tty_reset} "
+
+    download "${release_url}" "${temp_file}"
+
+    echo -e "${SUCCESS_UTF8}"
+    echo -ne "- ${tty_bold}Installing bebopc "
+
+    extract "${temp_file}" "${BEBOPC_PREFIX}/bin"
+
+    BEBOPC_PATH="${BEBOPC_PREFIX}/bin/bebopc"
+    if [ ! -f "${BEBOPC_PATH}" ]; then
+        abort "$(
+            cat <<EOABORT
+${ERROR_UTF8} 
+    ${tty_red}Could not locate \`${BEBOPC_PATH}\` after installation${tty_reset}
+EOABORT
+        )"
+    fi
+
+    echo -e "${SUCCESS_UTF8}"
+
+    if [[ ":${PATH}:" != *":${BEBOPC_PREFIX}/bin:"* ]]; then
+        warn "${tty_underline}${tty_white}${BEBOPC_PREFIX}/bin${tty_reset} is not in your ${tty_underline}${tty_white}PATH${tty_reset}.
+  Instructions on how to configure your shell for bebopc
+  can be found in the 'Next steps' section below."
+    fi
+
+    point "${ROCKET_UTF8} Installation successful!"
+
+    echo
+    ring_bell
+
+    point "Bebop is maintained by Rainway. Check out our startup:"
+    echo "$(
+        cat <<EOS
+  ${tty_underline}${tty_white}https://rainway.com${tty_reset}
+EOS
+    )
+"
+    case "${SHELL}" in
+    */bash*)
+        if [[ -r "${HOME}/.bash_profile" ]]; then
+            shell_profile="${HOME}/.bash_profile"
+        else
+            shell_profile="${HOME}/.profile"
+        fi
+        ;;
+    */zsh*)
+        shell_profile="${HOME}/.zprofile"
+        ;;
+    *)
+        shell_profile="${HOME}/.profile"
+        ;;
+    esac
+
+    point "${HAPPY_UTF8} Next steps:"
+    readonly additional_shellenv_commands="export PATH=\$PATH:$BEBOPC_PREFIX/bin"
+    echo "- Run this command in your terminal to add bebopc to your ${tty_underline}${tty_white}PATH${tty_reset}:"
+    printf "${tty_bold}${tty_white}    echo '%s' >> ${shell_profile}${tty_reset}\n" "${additional_shellenv_commands[@]}"
+    printf "${tty_bold}${tty_white}    %s${tty_reset}\n" "${additional_shellenv_commands[@]}"
+    if [[ ! -x "$BEBOPC_PATH" ]]; then
+        printf "${tty_bold}${tty_white}    %s${tty_reset}\n" "sudo chmod +x ${BEBOPC_PATH}"
+    fi
+
+    cat <<EOS
+- Run ${tty_bold}bebopc --help${tty_reset} to get started
+- Further documentation:
+    ${tty_underline}${tty_white}https://github.com/RainwayApp/bebop/wiki${tty_reset}
+EOS
+
+) ||
+    exit 1

--- a/Tools/bash/install.sh
+++ b/Tools/bash/install.sh
@@ -156,7 +156,7 @@ readonly os_version
 kernel_arch="${uname[2]}"
 case $kernel_arch in
 x86_64 | amd64)
-    os=x64
+    os_arch=x64
     ;;
 arm64 | aarch64)
     os_arch=arm64

--- a/Tools/bash/install.sh
+++ b/Tools/bash/install.sh
@@ -22,7 +22,7 @@ if [ -z "${BASH_VERSION:-}" ]; then
 fi
 
 ### Constants
-readonly BEBOPC_VERSION="${1:-2.3.1}"
+readonly BEBOPC_VERSION="${1:-0.0.0}"
 readonly BEBOP_RELEASE_URL="https://api.github.com/repos/rainwayapp/bebop/releases/tags/v${BEBOPC_VERSION}"
 
 readonly ARM64_ISSUE_LINK="https://github.com/RainwayApp/bebop/issues/185"
@@ -416,7 +416,7 @@ if [[ -x "$(which bebopc)" ]]; then
     fi
     # abort when the remote version is less than the installed version.
     # downgrading an install could change code generation
-    if version_lt "${BEBOPC_VERSION}" "${installed_bebopc_version}"; then
+    if version_lt "$(major_minor "${BEBOPC_VERSION}")" "$(major_minor "${installed_bebopc_version}")"; then
         abort "$(
             cat <<EOABORT
 $COLLISION_UTF8} ${tty_underline}${tty_white}$bebopc_name_and_version${tty_reset} is already installed,
@@ -430,7 +430,8 @@ EOABORT
 
     # warn and proceed if we're updating rather than installing
     # this is a warning because version changes may introduce code generator changes
-    if version_lt "${installed_bebopc_version}" "${BEBOPC_VERSION}"; then
+    # patches do not produce a warning
+    if version_lt "$(major_minor "${installed_bebopc_version}")" "$(major_minor "${BEBOPC_VERSION}")"; then
         warn "${tty_underline}${tty_white}$bebopc_name_and_version${tty_reset} will be upgraded to ${tty_underline}${tty_white}${BEBOPC_VERSION}${tty_reset}"
     fi
 


### PR DESCRIPTION
I've been working off of unix systems more frequently and got frustrated with how often I found myself manually installing bebopc.

Sure, I _could_ use npm, but I'm not going to, nor would a lot of other people. Plus, even installing bebop-tools globally doesn't add it to your PATH.

This script will handle installing and updating of bebopc in a portable manner. It should work fine in both interactive and non-interactive environments. It is 90% sanity checking and helper functions, 5% emojis, and 5% nicer.

![term](https://user-images.githubusercontent.com/1297077/152626654-81c807fc-8c87-4ac0-8a4a-2edeb074ca32.gif)

`bash -c "$(curl https://bebop.sh)"` 

~If I find myself with time I'll setup `bebop.sh` so it detects curl and wget user agents and returns the install script so we don't need a separate subdomain.~ did it