### PR TITLE
Parse 0x8 and -0x8 correctly

### DIFF
--- a/Core/Parser/SchemaParser.cs
+++ b/Core/Parser/SchemaParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -1201,9 +1201,13 @@ namespace Core.Parser
         }
         private static bool TryParseBigInteger(string lexeme, out BigInteger value)
         {
-            return lexeme.ToLowerInvariant().StartsWith("0x")
-                ? BigInteger.TryParse(lexeme.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value)
+            var negative = lexeme.StartsWith('-');
+            lexeme = lexeme.TrimStart('-');
+            var success = lexeme.ToLowerInvariant().StartsWith("0x")
+                ? BigInteger.TryParse("0" + lexeme.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value)
                 : BigInteger.TryParse(lexeme, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+            if (success && negative) value = -value;
+            return success;
         }
         
         private ConstDefinition MakeFunctionSignature(string serviceName, StructDefinition returnStruct,

--- a/Laboratory/C#/Test/UnitTest1.cs
+++ b/Laboratory/C#/Test/UnitTest1.cs
@@ -119,6 +119,8 @@ namespace Test
         {
             Assert.AreEqual((int)TestFlags.Read, 1);
             Assert.AreEqual((int)TestFlags.Write, 2);
+            Assert.AreEqual((int)TestFlags.Eight, 8);
+            Assert.AreEqual((int)TestFlags.MinusEight, -8);
             Assert.AreEqual(TestFlags.ReadWrite, TestFlags.Read | TestFlags.Write);
             // Check that the [Flags] attribute is doing its job:
             Assert.AreEqual((TestFlags.Read | TestFlags.SomethingElse).ToString(), "Read, SomethingElse");

--- a/Laboratory/Schemas/Valid/bitflags.bop
+++ b/Laboratory/Schemas/Valid/bitflags.bop
@@ -1,9 +1,11 @@
 [flags]
-enum TestFlags {
+enum TestFlags : int32 {
     None = 0;
     Read = 0x0001;
     Write = 1 << 1;
     ReadWrite = Read | Write;
     SomethingElse = 1 << 2;
     Complex = (Read | Write) | 0xF0 & 0x1F;
+    Eight = 0x8;
+    MinusEight = -0x8;
 }


### PR DESCRIPTION
A nasty hidden behavior of BigInteger.TryParse was making `0x8` parse as -8:

> If value is a hexadecimal string, the [TryParse(String, NumberStyles, IFormatProvider, BigInteger)](https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger.tryparse?view=net-6.0#system-numerics-biginteger-tryparse(system-string-system-globalization-numberstyles-system-iformatprovider-system-numerics-biginteger@)) method interprets value as a negative number stored by using two's complement representation if its first two hexadecimal digits are greater than or equal to 0x80. In other words, the method interprets the highest-order bit of the first byte in value as the sign bit. To make sure that a hexadecimal string is correctly interpreted as a positive number, the first digit in value must have a value of zero.

This PR makes `0x8` parse as 8, and `-0x8` (previously unsupported) parse as -8.