### PR TITLE
Introduce obj safe serialization trait

### DIFF
--- a/Core/Generators/Rust/RustGenerator.cs
+++ b/Core/Generators/Rust/RustGenerator.cs
@@ -286,7 +286,7 @@ namespace Core.Generators.Rust
                     .AppendLine()
                     .AppendLine("#[inline]")
                     .CodeBlock(
-                        "fn _serialize_chained<W: ::std::io::Write>(&self, dest: &mut W) -> ::bebop::SeResult<usize>",
+                        "fn _serialize_chained<W: ::std::io::Write + ?::core::marker::Sized>(&self, dest: &mut W) -> ::bebop::SeResult<usize>",
                         _tab,
                         () =>
                         {
@@ -465,7 +465,7 @@ namespace Core.Generators.Rust
                     .AppendLine();
 
                 bldr.CodeBlock(
-                        "fn _serialize_chained<W: ::std::io::Write>(&self, dest: &mut W) -> ::bebop::SeResult<usize>",
+                        "fn _serialize_chained<W: ::std::io::Write + ?::core::marker::Sized>(&self, dest: &mut W) -> ::bebop::SeResult<usize>",
                         _tab, () =>
                         {
                             if (d.Fields.Count == 0)
@@ -605,7 +605,7 @@ namespace Core.Generators.Rust
                         })
                         .AppendLine()
                         .CodeBlock(
-                            "fn _serialize_chained<W: ::std::io::Write>(&self, dest: &mut W) -> ::bebop::SeResult<usize>",
+                            "fn _serialize_chained<W: ::std::io::Write + ?::core::marker::Sized>(&self, dest: &mut W) -> ::bebop::SeResult<usize>",
                             _tab, () =>
                             {
                                 WriteMessageSerialization(builder, d);
@@ -922,7 +922,7 @@ namespace Core.Generators.Rust
                 }).AppendLine();
 
                 builder.CodeBlock(
-                    "fn _serialize_chained<W: ::std::io::Write>(&self, dest: &mut W) -> ::bebop::SeResult<usize>",
+                    "fn _serialize_chained<W: ::std::io::Write + ?::core::marker::Sized>(&self, dest: &mut W) -> ::bebop::SeResult<usize>",
                     _tab, () =>
                     {
                         builder.AppendLine("let size = self.serialized_size();")
@@ -1249,7 +1249,7 @@ namespace Core.Generators.Rust
             WriteDocumentation(bldr, fnDef.Documentation);
             WriteDeprecation(bldr, fnDef.Attributes);
             bldr.CodeBlock(
-                $"pub fn {fnName}_raw<'data>(&self, {timeoutArg}, payload: &'data super::{argName}) -> ::bebop::rpc::TransportResult<impl 'data + Sized + ::core::future::Future<Output = ::bebop::rpc::RemoteRpcResponse<{retName}>>>",
+                $"pub fn {fnName}_raw<'data>(&self, {timeoutArg}, payload: &'data super::{argName}) -> ::bebop::rpc::TransportResult<impl 'data + ::core::marker::Sized + ::core::future::Future<Output = ::bebop::rpc::RemoteRpcResponse<{retName}>>>",
                 _tab,
                 () =>
                 {

--- a/Runtime/Rust/benches/slice_wrapper.rs
+++ b/Runtime/Rust/benches/slice_wrapper.rs
@@ -24,7 +24,7 @@ impl<'raw> SubRecord<'raw> for Fixed {
         Self::SERIALIZED_SIZE
     }
 
-    fn _serialize_chained<W: Write>(&self, dest: &mut W) -> SeResult<usize> {
+    fn _serialize_chained<W: Write + ?Sized>(&self, dest: &mut W) -> SeResult<usize> {
         self.a._serialize_chained(dest)?;
         self.b._serialize_chained(dest)?;
         Ok(9)

--- a/Runtime/Rust/src/rpc/mod.rs
+++ b/Runtime/Rust/src/rpc/mod.rs
@@ -68,7 +68,7 @@ pub(crate) mod test_struct {
         fn serialized_size(&self) -> usize {
             0
         }
-        fn _serialize_chained<W: Write>(&self, dest: &mut W) -> SeResult<usize> {
+        fn _serialize_chained<W: Write + ?Sized>(&self, dest: &mut W) -> SeResult<usize> {
             dest.write_all(&[self.v])?;
             Ok(1)
         }

--- a/Runtime/Rust/src/types/slice.rs
+++ b/Runtime/Rust/src/types/slice.rs
@@ -206,7 +206,7 @@ mod test {
             Self::SERIALIZED_SIZE
         }
 
-        fn _serialize_chained<W: Write>(&self, dest: &mut W) -> SeResult<usize> {
+        fn _serialize_chained<W: Write + ?Sized>(&self, dest: &mut W) -> SeResult<usize> {
             self.a._serialize_chained(dest)?;
             self.b._serialize_chained(dest)?;
             Ok(9)


### PR DESCRIPTION
For benchmarking realized I wanted a way to have `&dyn Record` which is impossible, so created a new trait which will support it and also had to carry though the `?Sized` relaxation on the `Write` type for serialization which we should have done anyway since we don't need it to be sized.