### PR TITLE
Catch more out-of-bound panics in Rust runtime

### DIFF
--- a/Runtime/Rust/src/serialization/mod.rs
+++ b/Runtime/Rust/src/serialization/mod.rs
@@ -88,12 +88,12 @@ impl<'raw> SubRecord<'raw> for &'raw str {
 
     fn _deserialize_chained(raw: &'raw [u8]) -> DeResult<(usize, Self)> {
         let len = read_len(raw)?;
-        let raw_str = &raw
-            .get(LEN_SIZE..len + LEN_SIZE)
-            .ok_or(DeserializeError::CorruptFrame)?;
-        if raw_str.len() < len {
-            return Err(DeserializeError::MoreDataExpected(len - raw_str.len()));
+        if len + LEN_SIZE > raw.len() {
+            return Err(DeserializeError::MoreDataExpected(
+                len + LEN_SIZE - raw.len(),
+            ));
         }
+        let raw_str = &raw[LEN_SIZE..len + LEN_SIZE];
         #[cfg(not(feature = "unchecked"))]
         {
             Ok((len + LEN_SIZE, std::str::from_utf8(raw_str)?))


### PR DESCRIPTION
The Rust runtime seems to assume in a few places that over-slicing an array returns a truncated result:
```rs
raw[0..16]
    .try_into()
    .map_err(|_| DeserializeError::MoreDataExpected(16 - raw.len()))?,
```
But actually `raw[0..16]` already panics if `raw` is shorter than 16 bytes. So we have to check this _before_ slicing.